### PR TITLE
Update translations workflow to use ubuntu-latest

### DIFF
--- a/.github/workflows/update-translations.yml
+++ b/.github/workflows/update-translations.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   run:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
         uses: actions/checkout@v3


### PR DESCRIPTION
### Motivation
- Replace the unavailable `ubuntu-20.04` runner with `ubuntu-latest` so the `update-translations` job can be picked up by current GitHub-hosted runners.

### Description
- Changed `runs-on` in `.github/workflows/update-translations.yml` from `ubuntu-20.04` to `ubuntu-latest`.

### Testing
- No automated tests were run for this CI configuration change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6991da95bf24832690370b1ca11e19bc)