### PR TITLE
Prefer packaged Phoenicis launcher and preserve JavaFX module-path fallback

### DIFF
--- a/phoenicis-dist/src/launchers/phoenicis
+++ b/phoenicis-dist/src/launchers/phoenicis
@@ -4,35 +4,40 @@ set -e
 
 APP_HOME="/usr/share/phoenicis"
 
-JAVA_BIN="$APP_HOME/lib/runtime/bin/java"
-if [ ! -x "$JAVA_BIN" ]; then
-    JAVA_BIN="java"
+for launcher in \
+    "$APP_HOME/phoenicis-playonlinux" \
+    "$APP_HOME/bin/phoenicis-playonlinux" \
+    "$APP_HOME/bin/Phoenicis PlayOnLinux" \
+    "$APP_HOME/PhoenicisPlayOnLinux"; do
+    if [ -x "$launcher" ]; then
+        exec "$launcher" "$@"
+    fi
+done
+
+for candidate in \
+    "$APP_HOME/lib/runtime/bin/java" \
+    "$APP_HOME/runtime/bin/java"; do
+    if [ -x "$candidate" ]; then
+        JAVA_BIN="$candidate"
+        break
+    fi
+done
+
+JAVA_BIN="${JAVA_BIN:-java}"
+
+MODULE_PATH="$APP_HOME/lib"
+if [ -d "$APP_HOME/lib/app" ]; then
+    MODULE_PATH="$MODULE_PATH:$APP_HOME/lib/app"
 fi
 
 if compgen -G "$APP_HOME/lib/app/*.jar" > /dev/null || compgen -G "$APP_HOME/lib/*.jar" > /dev/null; then
     exec "$JAVA_BIN" \
         --add-modules=jdk.crypto.ec,java.base,javafx.base,javafx.web,javafx.media,javafx.graphics,javafx.controls,java.naming,java.sql,java.scripting,jdk.internal.vm.ci,org.graalvm.truffle,java.management \
         --enable-native-access=javafx.graphics \
-        --module-path "$APP_HOME/lib" \
+        --module-path "$MODULE_PATH" \
         --upgrade-module-path="$APP_HOME/lib/compiler.jar:$APP_HOME/lib/app/compiler.jar" \
         -cp "$APP_HOME/lib/app/*:$APP_HOME/lib/*" \
         org.phoenicis.javafx.JavaFXApplication "$@"
-fi
-
-if [ -x "$APP_HOME/phoenicis-playonlinux" ]; then
-    exec "$APP_HOME/phoenicis-playonlinux" "$@"
-fi
-
-if [ -x "$APP_HOME/bin/phoenicis-playonlinux" ]; then
-    exec "$APP_HOME/bin/phoenicis-playonlinux" "$@"
-fi
-
-if [ -x "$APP_HOME/bin/Phoenicis PlayOnLinux" ]; then
-    exec "$APP_HOME/bin/Phoenicis PlayOnLinux" "$@"
-fi
-
-if [ -x "$APP_HOME/PhoenicisPlayOnLinux" ]; then
-    exec "$APP_HOME/PhoenicisPlayOnLinux" "$@"
 fi
 
 echo "Unable to find a runnable Phoenicis launcher in $APP_HOME" >&2


### PR DESCRIPTION
### Motivation
- Debian `.deb` installs on Ubuntu 24.04 can hit `Module javafx.base not found` when the manual Java invocation is used before a jpackage-generated launcher, so the packaged launcher should be preferred. 
- The fallback Java startup path must still work for layouts that ship only jars or a bundled runtime, so JVM discovery and module visibility must be retained.

### Description
- Attempt to execute packaged launchers first by iterating over `"$APP_HOME/phoenicis-playonlinux"`, `"$APP_HOME/bin/phoenicis-playonlinux"`, `"$APP_HOME/bin/Phoenicis PlayOnLinux"`, and `"$APP_HOME/PhoenicisPlayOnLinux"`, and `exec` the first one found. 
- Preserve bundled JVM discovery by checking both `"$APP_HOME/lib/runtime/bin/java"` and `"$APP_HOME/runtime/bin/java"` before falling back to system `java`. 
- Build a `MODULE_PATH` from `"$APP_HOME/lib"` and append `":$APP_HOME/lib/app"` when present, pass it as `--module-path "$MODULE_PATH"`, and keep the existing `--upgrade-module-path` and `-cp` usage so classpath and compiler jars remain unchanged.

### Testing
- Ran a shell syntax check with `bash -n phoenicis-dist/src/launchers/phoenicis`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6991db3b2b4483268f708bdd7325273d)