### PR TITLE
CI: create automatic GitHub release with Debian artifact

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,15 @@ jobs:
         run: |
           cd phoenicis-dist/src/scripts
           bash phoenicis-create-package.sh
+      - name: Create GitHub release
+        if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+        uses: ncipollo/release-action@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          artifactErrorsFailBuild: true
+          artifacts: phoenicis-dist/target/Phoenicis_5.0-SNAPSHOT.deb
+          automaticReleaseTag: latest
+          generateReleaseNotes: true
       - uses: actions/upload-artifact@v4
         with:
           name: Ubuntu


### PR DESCRIPTION
### Motivation
- Automatically publish the built Debian package to a GitHub Release when changes are pushed to `master` to simplify distribution and ensure the `Phoenicis_5.0-SNAPSHOT.deb` artifact is attached to a release.
- Use an automatic release tag (`latest`) and generated release notes so downstream consumers can easily find the most recent snapshot.

### Description
- Add a `Create GitHub release` step to `ubuntu-java-25` in `.github/workflows/ci.yml` that runs after package creation and only on `push` to `refs/heads/master`.
- Use `ncipollo/release-action@v1` with `token: ${{ secrets.GITHUB_TOKEN }}`, `artifactErrorsFailBuild: true`, `artifacts: phoenicis-dist/target/Phoenicis_5.0-SNAPSHOT.deb`, `automaticReleaseTag: latest`, and `generateReleaseNotes: true`.
- Keep the existing artifact upload step (`actions/upload-artifact@v4`) intact so CI artifacts continue to be uploaded as before.

### Testing
- Validated YAML parse of the modified workflow with `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/ci.yml'); puts 'OK'"`, which succeeded.
- Attempted YAML validation via Python but `PyYAML` was not available in the environment, so that check was not run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69920e966f2c8326b4ab86b27cd3abe4)