### PR TITLE
Fix invalid release-action input in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,8 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           artifactErrorsFailBuild: true
           artifacts: phoenicis-dist/target/Phoenicis_5.0-SNAPSHOT.deb
-          automaticReleaseTag: latest
+          tag: latest
+          allowUpdates: true
           generateReleaseNotes: true
       - uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
### Motivation
- The GitHub Actions release step used the unsupported `automaticReleaseTag` input which caused workflow validation/runtime errors, so the release configuration needed to be corrected.

### Description
- Updated `.github/workflows/ci.yml` to replace `automaticReleaseTag` with `tag: latest` and added `allowUpdates: true` to allow updating the `latest` release on subsequent pushes.

### Testing
- Verified the change by inspecting the workflow with `rg` and `git diff` and committed the update, and those file-level checks completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699217f3ffc4832686fe74af0160b0bb)