### PR TITLE
Suppress missing engine setting include errors and enable modern JS in script engine

### DIFF
--- a/phoenicis-engines/src/test/java/org/phoenicis/engines/EngineSettingsManagerTest.java
+++ b/phoenicis-engines/src/test/java/org/phoenicis/engines/EngineSettingsManagerTest.java
@@ -1,0 +1,222 @@
+package org.phoenicis.engines;
+
+import org.junit.Test;
+import org.phoenicis.repository.dto.ApplicationDTO;
+import org.phoenicis.repository.dto.CategoryDTO;
+import org.phoenicis.repository.dto.RepositoryDTO;
+import org.phoenicis.repository.dto.ScriptDTO;
+import org.phoenicis.repository.dto.TypeDTO;
+import org.phoenicis.scripts.engine.PhoenicisScriptEngineFactory;
+import org.phoenicis.scripts.engine.implementation.PhoenicisScriptEngine;
+import org.phoenicis.scripts.exceptions.IncludeException;
+
+import java.io.InputStreamReader;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.AbstractExecutorService;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class EngineSettingsManagerTest {
+    @Test
+    public void shouldIgnoreMissingSettingScript() {
+        final AtomicReference<String> includeCall = new AtomicReference<>();
+        final AtomicReference<Boolean> errorCallbackCalled = new AtomicReference<>(false);
+
+        final PhoenicisScriptEngine scriptEngine = new PhoenicisScriptEngine() {
+            @Override
+            public void eval(InputStreamReader inputStreamReader, Consumer<Exception> errorCallback) {
+                // not used in this test
+            }
+
+            @Override
+            public void eval(String script, Runnable doneCallback, Consumer<Exception> errorCallback) {
+                // not used in this test
+            }
+
+            @Override
+            public Object evalAndReturn(String line, Consumer<Exception> errorCallback) {
+                includeCall.set(line);
+                errorCallback.accept(new IncludeException("engines.wine.settings.retina", new RuntimeException()));
+                return "";
+            }
+
+            @Override
+            public void put(String name, Object object, Consumer<Exception> errorCallback) {
+                // not used in this test
+            }
+
+            @Override
+            public void addErrorHandler(Consumer<Exception> errorHandler) {
+                // not used in this test
+            }
+        };
+
+        final PhoenicisScriptEngineFactory scriptEngineFactory = new PhoenicisScriptEngineFactory(null, null) {
+            @Override
+            public PhoenicisScriptEngine createEngine() {
+                return scriptEngine;
+            }
+        };
+
+        final ExecutorService directExecutor = new AbstractExecutorService() {
+            @Override
+            public void shutdown() {
+                // no-op
+            }
+
+            @Override
+            public List<Runnable> shutdownNow() {
+                return Collections.emptyList();
+            }
+
+            @Override
+            public boolean isShutdown() {
+                return false;
+            }
+
+            @Override
+            public boolean isTerminated() {
+                return false;
+            }
+
+            @Override
+            public boolean awaitTermination(long timeout, java.util.concurrent.TimeUnit unit) {
+                return true;
+            }
+
+            @Override
+            public void execute(Runnable command) {
+                command.run();
+            }
+        };
+
+        final EngineSettingsManager manager = new EngineSettingsManager(scriptEngineFactory, directExecutor);
+
+        final RepositoryDTO repository = new RepositoryDTO.Builder()
+                .withTypes(Collections.singletonList(new TypeDTO.Builder()
+                        .withId("engines")
+                        .withCategories(Collections.singletonList(new CategoryDTO.Builder()
+                                .withId("engines.wine")
+                                .withApplications(Collections.singletonList(new ApplicationDTO.Builder()
+                                        .withId("engines.wine.settings")
+                                        .withScripts(Collections.singletonList(new ScriptDTO.Builder()
+                                                .withId("engines.wine.settings.retina")
+                                                .build()))
+                                        .build()))
+                                .build()))
+                        .build()))
+                .build();
+
+        final AtomicReference<Map<String, List<EngineSetting>>> result = new AtomicReference<>();
+
+        manager.fetchAvailableEngineSettings(repository, result::set, e -> errorCallbackCalled.set(true));
+
+        assertEquals("include(\"engines.wine.settings.retina\");", includeCall.get());
+        assertTrue(result.get().containsKey("wine"));
+        assertTrue(result.get().get("wine").isEmpty());
+        assertFalse(errorCallbackCalled.get());
+    }
+
+    @Test
+    public void shouldForwardNonIncludeErrorsToErrorCallback() {
+        final AtomicReference<Boolean> errorCallbackCalled = new AtomicReference<>(false);
+
+        final PhoenicisScriptEngine scriptEngine = new PhoenicisScriptEngine() {
+            @Override
+            public void eval(InputStreamReader inputStreamReader, Consumer<Exception> errorCallback) {
+                // not used in this test
+            }
+
+            @Override
+            public void eval(String script, Runnable doneCallback, Consumer<Exception> errorCallback) {
+                // not used in this test
+            }
+
+            @Override
+            public Object evalAndReturn(String line, Consumer<Exception> errorCallback) {
+                errorCallback.accept(new RuntimeException("boom"));
+                return "";
+            }
+
+            @Override
+            public void put(String name, Object object, Consumer<Exception> errorCallback) {
+                // not used in this test
+            }
+
+            @Override
+            public void addErrorHandler(Consumer<Exception> errorHandler) {
+                // not used in this test
+            }
+        };
+
+        final PhoenicisScriptEngineFactory scriptEngineFactory = new PhoenicisScriptEngineFactory(null, null) {
+            @Override
+            public PhoenicisScriptEngine createEngine() {
+                return scriptEngine;
+            }
+        };
+
+        final ExecutorService directExecutor = new AbstractExecutorService() {
+            @Override
+            public void shutdown() {
+                // no-op
+            }
+
+            @Override
+            public List<Runnable> shutdownNow() {
+                return Collections.emptyList();
+            }
+
+            @Override
+            public boolean isShutdown() {
+                return false;
+            }
+
+            @Override
+            public boolean isTerminated() {
+                return false;
+            }
+
+            @Override
+            public boolean awaitTermination(long timeout, java.util.concurrent.TimeUnit unit) {
+                return true;
+            }
+
+            @Override
+            public void execute(Runnable command) {
+                command.run();
+            }
+        };
+
+        final EngineSettingsManager manager = new EngineSettingsManager(scriptEngineFactory, directExecutor);
+
+        final RepositoryDTO repository = new RepositoryDTO.Builder()
+                .withTypes(Collections.singletonList(new TypeDTO.Builder()
+                        .withId("engines")
+                        .withCategories(Collections.singletonList(new CategoryDTO.Builder()
+                                .withId("engines.wine")
+                                .withApplications(Collections.singletonList(new ApplicationDTO.Builder()
+                                        .withId("engines.wine.settings")
+                                        .withScripts(Collections.singletonList(new ScriptDTO.Builder()
+                                                .withId("engines.wine.settings.retina")
+                                                .build()))
+                                        .build()))
+                                .build()))
+                        .build()))
+                .build();
+
+        manager.fetchAvailableEngineSettings(repository, ignored -> {
+            // ignored in this scenario
+        }, e -> errorCallbackCalled.set(true));
+
+        assertTrue(errorCallbackCalled.get());
+    }
+
+}

--- a/phoenicis-scripts/src/main/java/org/phoenicis/scripts/engine/ScriptEngineType.java
+++ b/phoenicis-scripts/src/main/java/org/phoenicis/scripts/engine/ScriptEngineType.java
@@ -14,7 +14,8 @@ public enum ScriptEngineType {
         public PhoenicisScriptEngine createScriptEngine() {
             return new PolyglotScriptEngine("js",
                     Map.of("js.nashorn-compat", "true",
-                            "js.foreign-object-prototype", "true"));
+                            "js.foreign-object-prototype", "true",
+                            "js.ecmascript-version", "2021"));
         }
     };
 

--- a/phoenicis-scripts/src/test/java/org/phoenicis/scripts/engine/ScriptEngineTypeTest.java
+++ b/phoenicis-scripts/src/test/java/org/phoenicis/scripts/engine/ScriptEngineTypeTest.java
@@ -1,0 +1,21 @@
+package org.phoenicis.scripts.engine;
+
+import org.graalvm.polyglot.Value;
+import org.junit.Test;
+import org.phoenicis.scripts.engine.implementation.PhoenicisScriptEngine;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+public class ScriptEngineTypeTest {
+    @Test
+    public void shouldSupportConstDeclarationsInEvaluatedScripts() {
+        final PhoenicisScriptEngine scriptEngine = ScriptEngineType.GRAAL.createScriptEngine();
+
+        final Value result = (Value) scriptEngine.evalAndReturn("const answer = 42; answer;", exception -> {
+            fail(exception.getMessage());
+        });
+
+        assertEquals(42, result.asInt());
+    }
+}


### PR DESCRIPTION
### Motivation
- Loading engine settings currently surfaces fatal errors when optional/absent setting scripts are referenced (e.g. `engines.wine.settings.retina`), which should be tolerated. 
- Include failures can be wrapped by host exceptions, so detection must inspect the cause chain. 
- Evaluated scripts should support modern JS syntax (`const` etc.) for GraalJS-based script execution. 

### Description
- Update `EngineSettingsManager` to capture include evaluation errors locally and only forward unexpected/non-include exceptions to the external `errorCallback`. 
- Add a helper `isMissingSettingInclude(Throwable)` that walks the cause chain and treats `IncludeException` (including wrapped instances) as a missing optional include to be ignored. 
- Add `EngineSettingsManagerTest` with two tests that verify missing include errors are ignored and that non-include errors are forwarded to the error callback. 
- Update `ScriptEngineType` to enable `js.ecmascript-version=2021` in the Graal `PolyglotScriptEngine` and add `ScriptEngineTypeTest` to verify `const` declarations work in evaluated scripts. 

### Testing
- Added unit tests: `EngineSettingsManagerTest` (covers ignored include and forwarded non-include errors) and `ScriptEngineTypeTest` (verifies modern JS `const` support). 
- Attempted: `mvn -pl phoenicis-engines -Dtest=EngineSettingsManagerTest test -DskipITs`, but the run failed due to environment dependency resolution (Maven plugin `net.revelc.code.formatter:formatter-maven-plugin:2.23.0` could not be downloaded from Maven Central; HTTP 403). 
- No automated tests completed successfully in this environment because of the Maven dependency resolution issue; tests are present and should pass once dependencies are available.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69921a4ab2288326b725cd9fbe12afe1)