### PR TITLE
Update CI release flow with generated alpha tags

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,7 +113,7 @@ jobs:
         id: generate_tag
         run: |
           git fetch --tags
-          latest_number=$(git tag -l 'phoenicis-5.0-alpha*' | sed -E 's/^phoenicis-5\.0-alpha//' | awk '/^[0-9]+$/ { print $1 }' | sort -n | tail -n 1)
+          latest_number=$(git tag -l 'v5.0.0-alpha*' | sed -E 's/^v5\.0\.0-alpha//' | awk '/^[0-9]+$/ { print $1 }' | sort -n | tail -n 1)
 
           if [ -z "$latest_number" ]; then
             next_number="01"
@@ -121,7 +121,7 @@ jobs:
             next_number=$(printf "%02d" "$((10#$latest_number + 1))")
           fi
 
-          echo "tag=phoenicis-5.0-alpha${next_number}" >> "$GITHUB_OUTPUT"
+          echo "tag=v5.0.0-alpha${next_number}" >> "$GITHUB_OUTPUT"
       - name: Create GitHub release
         uses: ncipollo/release-action@v1
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
     - master
+  workflow_dispatch:
 
 jobs:
   ubuntu-java-25:
@@ -27,16 +28,6 @@ jobs:
         run: |
           cd phoenicis-dist/src/scripts
           bash phoenicis-create-package.sh
-      - name: Create GitHub release
-        if: github.event_name == 'push' && github.ref == 'refs/heads/master'
-        uses: ncipollo/release-action@v1
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          artifactErrorsFailBuild: true
-          artifacts: phoenicis-dist/target/Phoenicis_5.0-SNAPSHOT.deb
-          tag: latest
-          allowUpdates: true
-          generateReleaseNotes: true
       - uses: actions/upload-artifact@v4
         with:
           name: Ubuntu
@@ -100,3 +91,43 @@ jobs:
       #    name: Mac OS
       #    path: phoenicis-dist/target/packages/*.app
       #    if-no-files-found: error
+
+  release:
+    name: Release
+    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
+    needs:
+      - ubuntu-java-25
+      - flatpak
+      - macos-java-25
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v3
+      - name: Download Ubuntu artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: Ubuntu
+          path: release-artifacts
+      - name: Generate release tag
+        id: generate_tag
+        run: |
+          git fetch --tags
+          latest_number=$(git tag -l 'phoenicis-5.0-alpha*' | sed -E 's/^phoenicis-5\.0-alpha//' | awk '/^[0-9]+$/ { print $1 }' | sort -n | tail -n 1)
+
+          if [ -z "$latest_number" ]; then
+            next_number="01"
+          else
+            next_number=$(printf "%02d" "$((10#$latest_number + 1))")
+          fi
+
+          echo "tag=phoenicis-5.0-alpha${next_number}" >> "$GITHUB_OUTPUT"
+      - name: Create GitHub release
+        uses: ncipollo/release-action@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          artifactErrorsFailBuild: true
+          artifacts: release-artifacts/Phoenicis_5.0-SNAPSHOT.deb
+          tag: ${{ steps.generate_tag.outputs.tag }}
+          allowUpdates: false
+          generateReleaseNotes: true


### PR DESCRIPTION
### Motivation
- Allow the CI workflow to be triggered manually from the Actions UI by adding a `workflow_dispatch` trigger. 
- Ensure releases are only created after all build jobs (`ubuntu`, `macos`, and `flatpak`) succeed by moving release publishing into a dependent job. 
- Generate deterministic, incrementing alpha release tags instead of using a static `latest` tag to better track published artifacts. 

### Description
- Added `workflow_dispatch` to the `CI` workflow so the workflow can be started manually. 
- Removed the inline release step from the `ubuntu-java-25` job and added a dedicated `release` job that `needs` `ubuntu-java-25`, `flatpak`, and `macos-java-25`. 
- Implemented automatic tag generation in the `release` job that computes the next `phoenicis-5.0-alphaXX` tag by scanning existing `phoenicis-5.0-alpha*` tags and incrementing the numeric suffix. 
- Updated the release publishing to download the Ubuntu artifact, use the generated tag for the GitHub release, and publish the artifact with `ncipollo/release-action@v1`. 

### Testing
- The patch application reported success when updating `.github/workflows/ci.yml`. 
- The modified workflow file was parsed successfully with Ruby YAML loader using `YAML.load_file` which returned `YAML parse OK`. 
- A Python YAML parse attempt failed because the `PyYAML` module was not installed in the environment, indicating an environment limitation rather than a YAML syntax error.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6992bf65f10c8326ab225af3d346dcd8)