### PR TITLE
Limit auto-merge workflow to Dependabot pull request runs

### DIFF
--- a/.github/workflows/merge-me.yml
+++ b/.github/workflows/merge-me.yml
@@ -14,10 +14,14 @@ permissions:
 jobs:
   merge-me:
     name: Merge me!
+    if: >-
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.actor.login == 'dependabot[bot]' &&
+      github.event.workflow_run.pull_requests[0]
     runs-on: ubuntu-latest
     steps:
-      - if: ${{ github.event.workflow_run.conclusion == 'success' }}
-        name: Merge me!
+      - name: Merge me!
         uses: ridedott/merge-me-action@v2
         with:
           GITHUB_TOKEN: ${{ secrets.DEPENDABOT_AUTO_MERGE || secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
### Motivation
- Prevent the `merge-me` job from running for `workflow_run` events that are not Dependabot pull requests and avoid warnings like `Unable to fetch pull request information` when no PR context exists.

### Description
- Add a job-level `if` to `.github/workflows/merge-me.yml` that requires `github.event.workflow_run.conclusion == 'success'`, `github.event.workflow_run.event == 'pull_request'`, `github.event.workflow_run.actor.login == 'dependabot[bot]'`, and a present `github.event.workflow_run.pull_requests[0]`, and remove the now-redundant step-level `if` guard.

### Testing
- Parsed the updated workflow with `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/merge-me.yml'); puts 'ok'"`, which printed `ok` indicating the YAML is valid.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6992c8aade108326b1101755728448cf)