### PR TITLE
Add compatibility launcher for packaged PlayOnLinux binary

### DIFF
--- a/phoenicis-dist/src/scripts/phoenicis-create-package-java12.sh
+++ b/phoenicis-dist/src/scripts/phoenicis-create-package-java12.sh
@@ -100,6 +100,15 @@ EOF
     cp -a "$SCRIPT_PATH/../launchers/phoenicis" $packageName/usr/bin/phoenicis
     chmod +x $packageName/usr/bin/phoenicis
 
+    launcherCompatibilityDir="$packageName/usr/share/phoenicis/bin"
+    mkdir -p "$launcherCompatibilityDir"
+    cat << 'EOF_LAUNCHER' > "$launcherCompatibilityDir/Phoenicis PlayOnLinux"
+#!/bin/sh
+
+exec /usr/bin/phoenicis "$@"
+EOF_LAUNCHER
+    chmod +x "$launcherCompatibilityDir/Phoenicis PlayOnLinux"
+
     cp "$SCRIPT_PATH/../resources/Phoenicis.desktop" "$packageName/usr/share/applications"
     cp "$SCRIPT_PATH/../resources/phoenicis.png" "$packageName/usr/share/pixmaps"
     cp "$SCRIPT_PATH/../resources/phoenicis-16.png" "$packageName/usr/share/pixmaps"

--- a/phoenicis-dist/src/scripts/phoenicis-create-package.sh
+++ b/phoenicis-dist/src/scripts/phoenicis-create-package.sh
@@ -146,6 +146,15 @@ EOF_CONTROL
     cp -a "$SCRIPT_PATH/../launchers/phoenicis" "$packageName/usr/bin/phoenicis"
     chmod +x "$packageName/usr/bin/phoenicis"
 
+    launcherCompatibilityDir="$packageName/usr/share/phoenicis/bin"
+    mkdir -p "$launcherCompatibilityDir"
+    cat << 'EOF_LAUNCHER' > "$launcherCompatibilityDir/Phoenicis PlayOnLinux"
+#!/bin/sh
+
+exec /usr/bin/phoenicis "$@"
+EOF_LAUNCHER
+    chmod +x "$launcherCompatibilityDir/Phoenicis PlayOnLinux"
+
     cp "$SCRIPT_PATH/../resources/Phoenicis.desktop" "$packageName/usr/share/applications"
     cp "$SCRIPT_PATH/../resources/phoenicis.png" "$packageName/usr/share/pixmaps"
     cp "$SCRIPT_PATH/../resources/phoenicis-16.png" "$packageName/usr/share/pixmaps"


### PR DESCRIPTION
### Motivation
- Ensure the generated app-image launcher `Phoenicis PlayOnLinux` can be invoked reliably by adding a compatibility wrapper that delegates to the packaged launcher at `/usr/bin/phoenicis` to avoid `Missing JavaFX application class org.phoenicis.javafx.JavaFXApplication` errors.
- Keep Linux packaging behavior consistent across the default and Java 12 packaging flows.

### Description
- Create a compatibility launcher directory at `/usr/share/phoenicis/bin` inside the Debian package and add a wrapper file `Phoenicis PlayOnLinux` that `exec`s `/usr/bin/phoenicis`.
- Apply the same wrapper creation code to both `phoenicis-dist/src/scripts/phoenicis-create-package.sh` and `phoenicis-dist/src/scripts/phoenicis-create-package-java12.sh` and make the wrapper executable.
- The wrapper is a minimal shell script (`#!/bin/sh`) that forwards all arguments with `exec /usr/bin/phoenicis "$@"`.

### Testing
- Ran a shell syntax check with `bash -n` on the updated scripts (`phoenicis-create-package.sh` and `phoenicis-create-package-java12.sh`), which succeeded.
- Verified the produced diff and committed the changes to the repository.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6992e550a64c832688da0e04e02f64a5)