### PR TITLE
Avoid recursive launcher fallback loop in phoenicis launcher

### DIFF
--- a/phoenicis-dist/src/launchers/phoenicis
+++ b/phoenicis-dist/src/launchers/phoenicis
@@ -14,12 +14,22 @@ done
 
 APP_HOME="${APP_HOME:-/usr/share/phoenicis}"
 
+SELF_PATH="$(readlink -f "$0")"
+
 for launcher in \
     "$APP_HOME/phoenicis-playonlinux" \
     "$APP_HOME/bin/phoenicis-playonlinux" \
-    "$APP_HOME/bin/Phoenicis PlayOnLinux" \
     "$APP_HOME/PhoenicisPlayOnLinux"; do
     if [ -x "$launcher" ]; then
+        launcher_path="$(readlink -f "$launcher")"
+
+        # Some distro packages ship /usr/share/phoenicis/bin/Phoenicis PlayOnLinux
+        # as a compatibility wrapper which executes /usr/bin/phoenicis again.
+        # Running that wrapper from here causes a recursive fork loop.
+        if [ "$launcher_path" = "$SELF_PATH" ] || grep -q "exec /usr/bin/phoenicis" "$launcher" 2>/dev/null; then
+            continue
+        fi
+
         if "$launcher" "$@"; then
             exit 0
         fi


### PR DESCRIPTION
### Motivation
- Prevent the launcher from re-executing distro compatibility wrappers that call `/usr/bin/phoenicis` and cause recursive fork loops and resource exhaustion.

### Description
- Add `SELF_PATH` and resolve each candidate `launcher_path` with `readlink -f`, skip candidates that resolve to the current script or contain `exec /usr/bin/phoenicis`, and remove the legacy compatibility entry so failure falls through to the Java fallback.

### Testing
- Performed a shell syntax check with `bash -n phoenicis-dist/src/launchers/phoenicis` which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6992e99b9f048326880e37e5cf7534fa)