### PR TITLE
Prevent ConcurrentModificationException in MultipleRepository (snapshot + sync)

### DIFF
--- a/phoenicis-repository/src/test/java/org/phoenicis/repository/types/MultipleRepositoryTest.java
+++ b/phoenicis-repository/src/test/java/org/phoenicis/repository/types/MultipleRepositoryTest.java
@@ -23,7 +23,9 @@ import org.junit.Test;
 import org.phoenicis.repository.dto.RepositoryDTO;
 import org.phoenicis.repository.dto.TypeDTO;
 
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.List;
 
 import static org.junit.Assert.assertEquals;
 
@@ -61,5 +63,25 @@ public class MultipleRepositoryTest {
 
         final MultipleRepository multipleRepository = new MultipleRepository(firstSource, secondSource, thirdSource);
         assertEquals(3, multipleRepository.fetchInstallableApplications().getTypes().get(0).getCategories().size());
+    }
+
+    @Test
+    public void testConstructorMakesDefensiveCopyOfRepositoriesList() {
+        final Repository source = () -> new RepositoryDTO.Builder().withTypes(Collections.singletonList(
+                new TypeDTO.Builder()
+                        .withId("Type 1")
+                        .withCategories(Collections.singletonList(
+                                new CategoryDTO.Builder().withId("Category 1").build()))
+                        .build()))
+                .build();
+
+        final List<Repository> repositories = new ArrayList<>();
+        repositories.add(source);
+
+        final MultipleRepository multipleRepository = new MultipleRepository(repositories);
+        repositories.clear();
+
+        assertEquals(1, multipleRepository.size());
+        assertEquals(1, multipleRepository.fetchInstallableApplications().getTypes().get(0).getCategories().size());
     }
 }


### PR DESCRIPTION
### Motivation
- Fix a reported `ConcurrentModificationException` occurring during `MultipleRepository.fetchInstallableApplications()` when the internal repositories list is mutated while being processed in parallel.
- Ensure repository list handling is thread-safe and immune to external mutations passed into the constructor.

### Description
- Make the internal `repositories` list `final` and defensively copy the list in the `MultipleRepository(List<Repository>)` constructor.
- Take a synchronized snapshot via `getRepositoriesSnapshot()` and use that snapshot for the parallel stream in `fetchInstallableApplications()` and for merging to avoid concurrent iteration of a mutable list.
- Synchronize mutating/read methods (`addRepository`, `addRepository(index, ...)`, `removeRepository`, `moveRepository`, `size`) and update `onDelete`, `toString`, `equals`, and `hashCode` to use snapshots instead of traversing the mutable list.
- Add a unit test `testConstructorMakesDefensiveCopyOfRepositoriesList` to verify the constructor makes a defensive copy and that external mutation of the original list does not affect the `MultipleRepository` behavior.

### Testing
- Ran `mvn -pl phoenicis-repository -Dtest=MultipleRepositoryTest test` to execute the updated tests, but the build failed in this environment due to Maven plugin resolution (the `formatter-maven-plugin:2.23.0` artifact could not be retrieved from Maven Central; HTTP 403), so tests could not be completed here.
- The new test `MultipleRepositoryTest#testConstructorMakesDefensiveCopyOfRepositoriesList` was added and is intended to exercise the defensive-copy behavior and fetch correctness.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6992ee31132c8326be1c167316d5751f)