### PR TITLE
Add manual run limit input to workflow cleanup job

### DIFF
--- a/.github/workflows/cleanup-workflow-runs.yml
+++ b/.github/workflows/cleanup-workflow-runs.yml
@@ -1,0 +1,57 @@
+name: Cleanup workflow runs
+
+on:
+  schedule:
+    - cron: '0 3 * * *'
+  workflow_dispatch:
+    inputs:
+      runs_to_delete:
+        description: Number of completed workflow runs to delete (manual runs only)
+        required: true
+        default: '25'
+
+permissions:
+  actions: write
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Delete completed workflow runs
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const isManualRun = context.eventName === 'workflow_dispatch';
+            const runsToDeleteInput = Number.parseInt(context.payload.inputs?.runs_to_delete || '0', 10);
+
+            if (isManualRun && (!Number.isInteger(runsToDeleteInput) || runsToDeleteInput < 1)) {
+              core.setFailed('runs_to_delete must be a positive integer.');
+              return;
+            }
+
+            const runs = await github.paginate(
+              github.rest.actions.listWorkflowRunsForRepo,
+              {
+                owner,
+                repo,
+                status: 'completed',
+                per_page: 100
+              }
+            );
+
+            const runsToDelete = isManualRun ? runs.slice(0, runsToDeleteInput) : runs;
+
+            core.info(`Found ${runs.length} completed workflow run(s).`);
+            core.info(`Deleting ${runsToDelete.length} workflow run(s).`);
+
+            for (const run of runsToDelete) {
+              await github.rest.actions.deleteWorkflowRun({
+                owner,
+                repo,
+                run_id: run.id
+              });
+
+              core.info(`Deleted run #${run.run_number} (${run.name})`);
+            }


### PR DESCRIPTION
### Motivation
- Give maintainers control when running the cleanup job manually so they can delete a limited number of completed workflow runs instead of deleting all completed runs.

### Description
- Add a `workflow_dispatch` input `runs_to_delete` to `.github/workflows/cleanup-workflow-runs.yml` with a default of `25` and a description. 
- Read the manual input from `context.payload.inputs?.runs_to_delete` and validate it is a positive integer, failing fast if not. 
- When triggered manually, delete only the first N completed runs as requested, while scheduled runs continue to delete all completed runs. 
- Log the total found completed runs and the number of runs being deleted, and report each deletion via `github.rest.actions.deleteWorkflowRun`.

### Testing
- Ran `git diff --check` and it returned no issues. 
- Verified the updated workflow YAML was emitted by inspecting the file contents and committed the change successfully. 
- No CI pipeline was executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6994b857b94c8326aafb9e96b889b733)