### PR TITLE
Migrate legacy scripts repository URL

### DIFF
--- a/phoenicis-repository/src/test/java/org/phoenicis/repository/FilesystemJsonRepositoryLocationLoaderTest.java
+++ b/phoenicis-repository/src/test/java/org/phoenicis/repository/FilesystemJsonRepositoryLocationLoaderTest.java
@@ -42,7 +42,8 @@ public class FilesystemJsonRepositoryLocationLoaderTest {
             final List<RepositoryLocation<? extends Repository>> loadedLocations = loader.loadRepositoryLocations();
             final GitRepositoryLocation migratedRepository = (GitRepositoryLocation) loadedLocations.get(0);
 
-            assertEquals("https://github.com/PhoenicisOrg/scripts", migratedRepository.getGitRepositoryUri().toString());
+            assertEquals("https://github.com/PhoenicisOrg/scripts",
+                    migratedRepository.getGitRepositoryUri().toString());
 
             final List<?> persistedLocations = objectMapper.readValue(temporaryFolder.getRoot().toPath()
                     .resolve("repositories.json").toFile(), List.class);

--- a/phoenicis-repository/src/test/java/org/phoenicis/repository/FilesystemJsonRepositoryLocationLoaderTest.java
+++ b/phoenicis-repository/src/test/java/org/phoenicis/repository/FilesystemJsonRepositoryLocationLoaderTest.java
@@ -1,0 +1,54 @@
+package org.phoenicis.repository;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.phoenicis.configuration.ObjectMapperFactory;
+import org.phoenicis.repository.location.GitRepositoryLocation;
+import org.phoenicis.repository.location.RepositoryLocation;
+import org.phoenicis.repository.types.Repository;
+
+import java.net.URI;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class FilesystemJsonRepositoryLocationLoaderTest {
+    @Test
+    public void testMigratesLegacyScriptsRepositoryUrl() throws Exception {
+        final TemporaryFolder temporaryFolder = new TemporaryFolder();
+        temporaryFolder.create();
+
+        try {
+            final ObjectMapper objectMapper = new ObjectMapperFactory().createObjectMapper();
+            final String repositoryListPath = temporaryFolder.newFile("repositories.json").getAbsolutePath();
+            final GitRepositoryLocation legacyRepository = new GitRepositoryLocation.Builder()
+                    .withGitRepositoryUri(new URI("https://github.com/ahmedmoselhi/scripts"))
+                    .withBranch("master")
+                    .build();
+
+            objectMapper.writeValue(temporaryFolder.getRoot().toPath().resolve("repositories.json").toFile(),
+                    Collections.singletonList(legacyRepository));
+
+            final FilesystemJsonRepositoryLocationLoader loader = new FilesystemJsonRepositoryLocationLoader(
+                    repositoryListPath,
+                    "https://github.com/PhoenicisOrg/scripts",
+                    "master",
+                    "/org/phoenicis/repository",
+                    objectMapper);
+
+            final List<RepositoryLocation<? extends Repository>> loadedLocations = loader.loadRepositoryLocations();
+            final GitRepositoryLocation migratedRepository = (GitRepositoryLocation) loadedLocations.get(0);
+
+            assertEquals("https://github.com/PhoenicisOrg/scripts", migratedRepository.getGitRepositoryUri().toString());
+
+            final List<?> persistedLocations = objectMapper.readValue(temporaryFolder.getRoot().toPath()
+                    .resolve("repositories.json").toFile(), List.class);
+            assertTrue(persistedLocations.toString().contains("https://github.com/PhoenicisOrg/scripts"));
+        } finally {
+            temporaryFolder.delete();
+        }
+    }
+}


### PR DESCRIPTION
### Motivation
- Some users had persisted repository entries that point to the old legacy scripts URL (`https://github.com/ahmedmoselhi/scripts`), which can cause stale/outdated script sources and installation errors. 
- The application should automatically heal existing saved repositories by rewriting legacy URLs to the configured default scripts repository to avoid manual intervention.

### Description
- Added a migration step in `FilesystemJsonRepositoryLocationLoader` that detects `https://github.com/ahmedmoselhi/scripts` and replaces it with the configured `defaultGitUrl`, then persists the updated repository list. 
- Introduced the constant `LEGACY_SCRIPTS_REPOSITORY_URL` and the helper method `migrateLegacyRepositoryLocations(...)` which performs the in-memory rewrite and calls `saveRepositories(...)` when changes are made. 
- The migration is invoked during `loadRepositoryLocations()` so legacy entries are rewritten at startup. 
- Added unit test `FilesystemJsonRepositoryLocationLoaderTest` that writes a temporary `repositories.json` containing the legacy URL and verifies that the loader rewrites and persists the updated URL.

### Testing
- Added the unit test `phoenicis-repository/src/test/java/org/phoenicis/repository/FilesystemJsonRepositoryLocationLoaderTest.java` which verifies migration and persistence. 
- Attempted to run `mvn -pl phoenicis-repository test -DskipITs`, but the build could not complete in this environment because Maven failed to resolve `net.revelc.code.formatter:formatter-maven-plugin:2.23.0` from Maven Central (HTTP 403), so the tests were not executed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6994bb44b6c48326b8aa3d7495c5d44c)