### PR TITLE
Avoid post-extraction freezes by skipping file-list tracking in engine URL installs

### DIFF
--- a/phoenicis-javafx/src/main/java/org/phoenicis/javafx/controller/engines/EnginesController.java
+++ b/phoenicis-javafx/src/main/java/org/phoenicis/javafx/controller/engines/EnginesController.java
@@ -317,9 +317,10 @@ public class EnginesController {
                             downloader.get(externalUrl, tempFile.toString(), progress -> {
                                 // no-op: progress already handled by downloader internals
                             });
-                            extractor.uncompress(tempFile.toFile(), targetDirectory.toFile(), progress -> {
-                                // no-op: extraction runs in background thread
-                            });
+                            extractor.uncompressWithoutTracking(tempFile.toFile(), targetDirectory.toFile(),
+                                    progress -> {
+                                        // no-op: extraction runs in background thread
+                                    });
                         } finally {
                             Files.deleteIfExists(tempFile);
                         }

--- a/phoenicis-tools/src/main/java/org/phoenicis/tools/archive/Extractor.java
+++ b/phoenicis-tools/src/main/java/org/phoenicis/tools/archive/Extractor.java
@@ -45,6 +45,10 @@ public class Extractor {
         return uncompress(new File(inputFile), new File(outputDir), onChange);
     }
 
+    public void uncompressWithoutTracking(String inputFile, String outputDir, Consumer<ProgressEntity> onChange) {
+        uncompress(new File(inputFile), new File(outputDir), onChange, false);
+    }
+
     /**
      * Uncompress a .tar file
      *
@@ -53,21 +57,30 @@ public class Extractor {
      * @return list of uncompressed files
      */
     public List<File> uncompress(File inputFile, File outputDir, Consumer<ProgressEntity> onChange) {
+        return uncompress(inputFile, outputDir, onChange, true);
+    }
+
+    public void uncompressWithoutTracking(File inputFile, File outputDir, Consumer<ProgressEntity> onChange) {
+        uncompress(inputFile, outputDir, onChange, false);
+    }
+
+    private List<File> uncompress(File inputFile, File outputDir, Consumer<ProgressEntity> onChange,
+            boolean trackExtractedFiles) {
         LOGGER.info(
                 String.format("Uncompressing %s to dir %s.", inputFile.getAbsolutePath(), outputDir.getAbsolutePath()));
 
         switch (fileAnalyser.getMimetype(inputFile)) {
             case "application/x-bzip2":
-                return tar.uncompressTarBz2File(inputFile, outputDir, onChange);
+                return tar.uncompressTarBz2File(inputFile, outputDir, onChange, trackExtractedFiles);
             case "application/x-gzip":
-                return tar.uncompressTarGzFile(inputFile, outputDir, onChange);
+                return tar.uncompressTarGzFile(inputFile, outputDir, onChange, trackExtractedFiles);
             case "application/x-xz":
-                return tar.uncompressTarXzFile(inputFile, outputDir, onChange);
+                return tar.uncompressTarXzFile(inputFile, outputDir, onChange, trackExtractedFiles);
             case "application/zip":
             case "application/x-dosexec":
-                return zip.uncompressZipFile(inputFile, outputDir, onChange);
+                return zip.uncompressZipFile(inputFile, outputDir, onChange, trackExtractedFiles);
             default:
-                return tar.uncompressTarFile(inputFile, outputDir, onChange);
+                return tar.uncompressTarFile(inputFile, outputDir, onChange, trackExtractedFiles);
         }
 
     }

--- a/phoenicis-tools/src/main/java/org/phoenicis/tools/archive/Tar.java
+++ b/phoenicis-tools/src/main/java/org/phoenicis/tools/archive/Tar.java
@@ -62,7 +62,8 @@ public class Tar {
         try (CountingInputStream countingInputStream = new CountingInputStream(new FileInputStream(inputFile));
                 InputStream inputStream = new BZip2CompressorInputStream(countingInputStream)) {
             final long finalSize = FileUtils.sizeOf(inputFile);
-            return uncompress(inputStream, countingInputStream, outputDir, finalSize, stateCallback, trackExtractedFiles);
+            return uncompress(inputStream, countingInputStream, outputDir, finalSize, stateCallback,
+                    trackExtractedFiles);
         } catch (IOException e) {
             throw new ArchiveException(TAR_ERROR_MESSAGE, e);
         }
@@ -77,7 +78,8 @@ public class Tar {
         try (CountingInputStream countingInputStream = new CountingInputStream(new FileInputStream(inputFile));
                 InputStream inputStream = new GZIPInputStream(countingInputStream)) {
             final long finalSize = FileUtils.sizeOf(inputFile);
-            return uncompress(inputStream, countingInputStream, outputDir, finalSize, stateCallback, trackExtractedFiles);
+            return uncompress(inputStream, countingInputStream, outputDir, finalSize, stateCallback,
+                    trackExtractedFiles);
         } catch (IOException e) {
             throw new ArchiveException(TAR_ERROR_MESSAGE, e);
         }
@@ -92,7 +94,8 @@ public class Tar {
         try (CountingInputStream countingInputStream = new CountingInputStream(new FileInputStream(inputFile));
                 InputStream inputStream = new XZCompressorInputStream(countingInputStream)) {
             final long finalSize = FileUtils.sizeOf(inputFile);
-            return uncompress(inputStream, countingInputStream, outputDir, finalSize, stateCallback, trackExtractedFiles);
+            return uncompress(inputStream, countingInputStream, outputDir, finalSize, stateCallback,
+                    trackExtractedFiles);
         } catch (IOException e) {
             throw new ArchiveException(TAR_ERROR_MESSAGE, e);
         }

--- a/phoenicis-tools/src/main/java/org/phoenicis/tools/archive/Tar.java
+++ b/phoenicis-tools/src/main/java/org/phoenicis/tools/archive/Tar.java
@@ -35,7 +35,7 @@ import org.slf4j.LoggerFactory;
 import java.io.*;
 import java.nio.file.Files;
 import java.nio.file.Paths;
-import java.util.LinkedList;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Consumer;
 import java.util.zip.GZIPInputStream;
@@ -54,39 +54,60 @@ public class Tar {
     }
 
     List<File> uncompressTarBz2File(File inputFile, File outputDir, Consumer<ProgressEntity> stateCallback) {
+        return uncompressTarBz2File(inputFile, outputDir, stateCallback, true);
+    }
+
+    List<File> uncompressTarBz2File(File inputFile, File outputDir, Consumer<ProgressEntity> stateCallback,
+            boolean trackExtractedFiles) {
         try (CountingInputStream countingInputStream = new CountingInputStream(new FileInputStream(inputFile));
                 InputStream inputStream = new BZip2CompressorInputStream(countingInputStream)) {
             final long finalSize = FileUtils.sizeOf(inputFile);
-            return uncompress(inputStream, countingInputStream, outputDir, finalSize, stateCallback);
+            return uncompress(inputStream, countingInputStream, outputDir, finalSize, stateCallback, trackExtractedFiles);
         } catch (IOException e) {
             throw new ArchiveException(TAR_ERROR_MESSAGE, e);
         }
     }
 
     List<File> uncompressTarGzFile(File inputFile, File outputDir, Consumer<ProgressEntity> stateCallback) {
+        return uncompressTarGzFile(inputFile, outputDir, stateCallback, true);
+    }
+
+    List<File> uncompressTarGzFile(File inputFile, File outputDir, Consumer<ProgressEntity> stateCallback,
+            boolean trackExtractedFiles) {
         try (CountingInputStream countingInputStream = new CountingInputStream(new FileInputStream(inputFile));
                 InputStream inputStream = new GZIPInputStream(countingInputStream)) {
             final long finalSize = FileUtils.sizeOf(inputFile);
-            return uncompress(inputStream, countingInputStream, outputDir, finalSize, stateCallback);
+            return uncompress(inputStream, countingInputStream, outputDir, finalSize, stateCallback, trackExtractedFiles);
         } catch (IOException e) {
             throw new ArchiveException(TAR_ERROR_MESSAGE, e);
         }
     }
 
     List<File> uncompressTarXzFile(File inputFile, File outputDir, Consumer<ProgressEntity> stateCallback) {
+        return uncompressTarXzFile(inputFile, outputDir, stateCallback, true);
+    }
+
+    List<File> uncompressTarXzFile(File inputFile, File outputDir, Consumer<ProgressEntity> stateCallback,
+            boolean trackExtractedFiles) {
         try (CountingInputStream countingInputStream = new CountingInputStream(new FileInputStream(inputFile));
                 InputStream inputStream = new XZCompressorInputStream(countingInputStream)) {
             final long finalSize = FileUtils.sizeOf(inputFile);
-            return uncompress(inputStream, countingInputStream, outputDir, finalSize, stateCallback);
+            return uncompress(inputStream, countingInputStream, outputDir, finalSize, stateCallback, trackExtractedFiles);
         } catch (IOException e) {
             throw new ArchiveException(TAR_ERROR_MESSAGE, e);
         }
     }
 
     List<File> uncompressTarFile(File inputFile, File outputDir, Consumer<ProgressEntity> stateCallback) {
+        return uncompressTarFile(inputFile, outputDir, stateCallback, true);
+    }
+
+    List<File> uncompressTarFile(File inputFile, File outputDir, Consumer<ProgressEntity> stateCallback,
+            boolean trackExtractedFiles) {
         try (CountingInputStream countingInputStream = new CountingInputStream(new FileInputStream(inputFile))) {
             final long finalSize = FileUtils.sizeOf(inputFile);
-            return uncompress(countingInputStream, countingInputStream, outputDir, finalSize, stateCallback);
+            return uncompress(countingInputStream, countingInputStream, outputDir, finalSize, stateCallback,
+                    trackExtractedFiles);
         } catch (IOException e) {
             throw new ArchiveException(TAR_ERROR_MESSAGE, e);
         }
@@ -152,8 +173,9 @@ public class Tar {
      *             if the process fails
      */
     private List<File> uncompress(final InputStream inputStream, CountingInputStream countingInputStream,
-            final File outputDir, long finalSize, Consumer<ProgressEntity> stateCallback) {
-        final List<File> uncompressedFiles = new LinkedList<>();
+            final File outputDir, long finalSize, Consumer<ProgressEntity> stateCallback,
+            boolean trackExtractedFiles) {
+        final List<File> uncompressedFiles = new ArrayList<>();
         int extractedEntries = 0;
         int lastNotifiedPercent = -1;
 
@@ -187,7 +209,9 @@ public class Tar {
                     }
                 }
 
-                uncompressedFiles.add(outputFile);
+                if (trackExtractedFiles) {
+                    uncompressedFiles.add(outputFile);
+                }
 
                 final double percent = (double) countingInputStream.getCount() / (double) finalSize * 100d;
                 final int roundedPercent = (int) percent;


### PR DESCRIPTION
### Motivation
- Prevent freezes observed after archive extraction when the code builds large in-memory lists of every extracted file during engine "Install from URL" flows.
- Narrow the optimization to the engine install path so callers that rely on the returned file list keep existing semantics while avoiding heavy bookkeeping where the list is unused.

### Description
- Added a no-bookkeeping extraction entrypoint `Extractor.uncompressWithoutTracking(...)` and an internal `uncompress(..., boolean trackExtractedFiles)` overload to control list tracking.
- Made TAR extraction methods accept an optional `trackExtractedFiles` flag and routed existing helpers to the new overloads while preserving default behavior via `true` defaults.
- Made ZIP extraction behave consistently by adding `uncompressZipFile(..., boolean trackExtractedFiles)` and switching from a stream/collector approach to an explicit loop that conditionally appends to the returned list.
- Wired the Wine engine URL install path to call `extractor.uncompressWithoutTracking(...)` so extraction still reports progress but avoids building the extracted-file list for this flow.

### Testing
- Attempted a partial build with `mvn -pl phoenicis-tools,phoenicis-javafx -DskipTests -Dformatter.skip=true -Dimpsort.skip=true compile`, but the run failed due to Maven unable to resolve `net.revelc.code.formatter:formatter-maven-plugin:2.23.0` (HTTP 403) from Maven Central.
- No unit tests were run in this environment because the compile step was blocked by the repository/plugin resolution issue.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6994ebc7f6e48326b1eb200911f1d02f)