### PR TITLE
Harden launcher against incompatible JavaFX module jars

### DIFF
--- a/phoenicis-dist/src/launchers/phoenicis
+++ b/phoenicis-dist/src/launchers/phoenicis
@@ -70,6 +70,17 @@ if [ -d "$APP_DIR" ]; then
     MODULE_PATH="$MODULE_PATH:$APP_DIR"
 fi
 
+JAVA_FX_MODULE_OPTS=(
+    --add-modules=javafx.base,javafx.web,javafx.media,javafx.graphics,javafx.controls
+    --enable-native-access=javafx.graphics,javafx.web
+    --module-path "$MODULE_PATH"
+)
+
+if ! "$JAVA_BIN" "${JVM_OPTS[@]}" "${JAVA_FX_MODULE_OPTS[@]}" -version >/dev/null 2>&1; then
+    echo "Skipping JavaFX module-path startup: incompatible Java/JavaFX module set detected." >&2
+    JAVA_FX_MODULE_OPTS=()
+fi
+
 COMPILER_UPGRADE_PATH="$LIB_DIR/compiler.jar"
 if [ -f "$APP_DIR/compiler.jar" ]; then
     COMPILER_UPGRADE_PATH="$COMPILER_UPGRADE_PATH:$APP_DIR/compiler.jar"
@@ -86,9 +97,7 @@ fi
 
 if compgen -G "$APP_DIR/phoenicis-javafx-*.jar" > /dev/null || compgen -G "$LIB_DIR/phoenicis-javafx-*.jar" > /dev/null; then
     exec "$JAVA_BIN" "${JVM_OPTS[@]}" \
-        --add-modules=javafx.base,javafx.web,javafx.media,javafx.graphics,javafx.controls \
-        --enable-native-access=javafx.graphics,javafx.web \
-        --module-path "$MODULE_PATH" \
+        "${JAVA_FX_MODULE_OPTS[@]}" \
         "${COMPILER_OPTS[@]}" \
         -cp "$APP_DIR/*:$LIB_DIR/*" \
         org.phoenicis.javafx.JavaFXApplication "$@"


### PR DESCRIPTION
### Motivation

- Prevent boot-layer failures such as `InvalidModuleDescriptorException` when the local JVM cannot load the packaged JavaFX/module jars by detecting incompatible Java/JavaFX module sets early.
- Provide a safe fallback to classpath startup when module-path startup is not supported by the runtime to improve launcher robustness across JVM/JavaFX combinations.

### Description

- Add a `JAVA_FX_MODULE_OPTS` array containing the JavaFX `--add-modules`, `--enable-native-access` and `--module-path` flags and reuse it for the final `java` exec.
- Probe compatibility by invoking `java -version` with `"${JVM_OPTS[@]}"` plus `"${JAVA_FX_MODULE_OPTS[@]}"` and log a warning then clear `JAVA_FX_MODULE_OPTS` on failure.
- Keep the existing compiler upgrade-path probe (`--upgrade-module-path`) unchanged and still applied when supported.

### Testing

- Performed a shell syntax check with `bash -n phoenicis-dist/src/launchers/phoenicis`, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a42468dc94832689311ad20611a336)