### PR TITLE
Add MappedList/ConcatenatedList and update JavaFX/Jakarta dependencies

### DIFF
--- a/phoenicis-javafx/pom.xml
+++ b/phoenicis-javafx/pom.xml
@@ -26,7 +26,6 @@
     <artifactId>phoenicis-javafx</artifactId>
     <properties>
         <project.root>${project.basedir}/../</project.root>
-        <openjfx.version>25.0.2</openjfx.version>
         <testfx.version>4.0.18</testfx.version>
     </properties>
     <dependencies>
@@ -110,6 +109,16 @@
         </dependency>
         <dependency>
             <groupId>org.openjfx</groupId>
+            <artifactId>javafx-base</artifactId>
+            <version>${openjfx.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.openjfx</groupId>
+            <artifactId>javafx-graphics</artifactId>
+            <version>${openjfx.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.openjfx</groupId>
             <artifactId>javafx-controls</artifactId>
             <version>${openjfx.version}</version>
         </dependency>
@@ -123,11 +132,6 @@
             <artifactId>openjfx-monocle</artifactId>
             <version>jdk-12.0.1+2</version>
             <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>com.github.PhoenicisOrg</groupId>
-            <artifactId>javafx-collections</artifactId>
-            <version>1.2.5</version>
         </dependency>
     </dependencies>
     <build>

--- a/phoenicis-javafx/src/main/java/org/phoenicis/javafx/collections/ConcatenatedList.java
+++ b/phoenicis-javafx/src/main/java/org/phoenicis/javafx/collections/ConcatenatedList.java
@@ -1,0 +1,76 @@
+package org.phoenicis.javafx.collections;
+
+import javafx.collections.FXCollections;
+import javafx.collections.ListChangeListener;
+import javafx.collections.ObservableList;
+import javafx.collections.ObservableListBase;
+
+import java.util.ArrayList;
+import java.util.IdentityHashMap;
+import java.util.List;
+import java.util.Map;
+
+public class ConcatenatedList<T> extends ObservableListBase<T> {
+    private final ObservableList<? extends ObservableList<? extends T>> sources;
+    private final Map<ObservableList<? extends T>, ListChangeListener<T>> listeners;
+    private final List<T> backingList;
+
+    private ConcatenatedList(ObservableList<? extends ObservableList<? extends T>> sources) {
+        this.sources = sources;
+        this.listeners = new IdentityHashMap<>();
+        this.backingList = new ArrayList<>();
+
+        bindSources();
+
+        this.sources.addListener((ListChangeListener<ObservableList<? extends T>>) change -> {
+            bindSources();
+            refresh();
+        });
+
+        refresh();
+    }
+
+    public static <T> ConcatenatedList<T> create(ObservableList<? extends ObservableList<? extends T>> sources) {
+        return new ConcatenatedList<>(sources);
+    }
+
+    @SafeVarargs
+    public static <T> ConcatenatedList<T> create(ObservableList<? extends T>... sources) {
+        return new ConcatenatedList<>(FXCollections.observableArrayList(sources));
+    }
+
+    @Override
+    public T get(int index) {
+        return backingList.get(index);
+    }
+
+    @Override
+    public int size() {
+        return backingList.size();
+    }
+
+    @SuppressWarnings("unchecked")
+    private void bindSources() {
+        listeners.forEach(ObservableList::removeListener);
+        listeners.clear();
+
+        for (ObservableList<? extends T> source : sources) {
+            final ListChangeListener<T> listener = change -> refresh();
+            ((ObservableList<T>) source).addListener(listener);
+            listeners.put(source, listener);
+        }
+    }
+
+    private void refresh() {
+        final List<T> oldValues = new ArrayList<>(backingList);
+
+        backingList.clear();
+        for (ObservableList<? extends T> source : sources) {
+            backingList.addAll(source);
+        }
+
+        beginChange();
+        nextReplace(0, backingList.size(), oldValues);
+        endChange();
+    }
+}

--- a/phoenicis-javafx/src/main/java/org/phoenicis/javafx/collections/MappedList.java
+++ b/phoenicis-javafx/src/main/java/org/phoenicis/javafx/collections/MappedList.java
@@ -1,0 +1,47 @@
+package org.phoenicis.javafx.collections;
+
+import javafx.collections.ListChangeListener;
+import javafx.collections.ObservableList;
+import javafx.collections.ObservableListBase;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Function;
+
+public class MappedList<T, S> extends ObservableListBase<S> {
+    private final ObservableList<T> source;
+    private final Function<T, S> mapper;
+    private final List<S> backingList;
+
+    public MappedList(ObservableList<T> source, Function<T, S> mapper) {
+        this.source = source;
+        this.mapper = mapper;
+        this.backingList = new ArrayList<>();
+
+        refresh();
+        this.source.addListener((ListChangeListener<T>) change -> refresh());
+    }
+
+    @Override
+    public S get(int index) {
+        return backingList.get(index);
+    }
+
+    @Override
+    public int size() {
+        return backingList.size();
+    }
+
+    private void refresh() {
+        final List<S> oldValues = new ArrayList<>(backingList);
+
+        backingList.clear();
+        for (T item : source) {
+            backingList.add(mapper.apply(item));
+        }
+
+        beginChange();
+        nextReplace(0, backingList.size(), oldValues);
+        endChange();
+    }
+}

--- a/phoenicis-multithreading/pom.xml
+++ b/phoenicis-multithreading/pom.xml
@@ -29,9 +29,9 @@
     </properties>
     <dependencies>
         <dependency>
-            <groupId>javax.annotation</groupId>
-            <artifactId>javax.annotation-api</artifactId>
-            <version>1.3.2</version>
+            <groupId>jakarta.annotation</groupId>
+            <artifactId>jakarta.annotation-api</artifactId>
+            <version>3.0.0</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/phoenicis-multithreading/src/main/java/org/phoenicis/multithreading/ControlledThreadPoolExecutorServiceCloser.java
+++ b/phoenicis-multithreading/src/main/java/org/phoenicis/multithreading/ControlledThreadPoolExecutorServiceCloser.java
@@ -18,7 +18,7 @@
 
 package org.phoenicis.multithreading;
 
-import javax.annotation.PreDestroy;
+import jakarta.annotation.PreDestroy;
 import java.util.concurrent.TimeUnit;
 
 public class ControlledThreadPoolExecutorServiceCloser implements AutoCloseable {

--- a/phoenicis-multithreading/src/main/java/org/phoenicis/multithreading/debug/ControlledThreadPoolExecutorDebugger.java
+++ b/phoenicis-multithreading/src/main/java/org/phoenicis/multithreading/debug/ControlledThreadPoolExecutorDebugger.java
@@ -5,7 +5,7 @@ import org.phoenicis.configuration.security.Safe;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.annotation.PreDestroy;
+import jakarta.annotation.PreDestroy;
 import java.util.concurrent.ExecutorService;
 
 /**

--- a/pom.xml
+++ b/pom.xml
@@ -53,11 +53,12 @@
         <logback.version>1.5.16</logback.version>
         <junit.version>4.13.2</junit.version>
         <mockito.version>5.22.0</mockito.version>
-        <spring.version>5.3.23</spring.version>
+        <spring.version>5.3.39</spring.version>
         <formatter-maven-plugin.version>2.29.0</formatter-maven-plugin.version>
         <graalvm.version>25.0.2</graalvm.version>
         <buildnumber.version>3.3.0</buildnumber.version>
         <jacoco.version>0.8.14</jacoco.version>
+        <openjfx.version>25.0.2</openjfx.version>
     </properties>
     <dependencyManagement>
         <dependencies>
@@ -82,6 +83,31 @@
                 <groupId>com.googlecode.gettext-commons</groupId>
                 <artifactId>gettext-commons</artifactId>
                 <version>0.9.8</version>
+            </dependency>
+            <dependency>
+                <groupId>org.openjfx</groupId>
+                <artifactId>javafx-base</artifactId>
+                <version>${openjfx.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.openjfx</groupId>
+                <artifactId>javafx-graphics</artifactId>
+                <version>${openjfx.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.openjfx</groupId>
+                <artifactId>javafx-controls</artifactId>
+                <version>${openjfx.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.openjfx</groupId>
+                <artifactId>javafx-web</artifactId>
+                <version>${openjfx.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.openjfx</groupId>
+                <artifactId>javafx-media</artifactId>
+                <version>${openjfx.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>
@@ -231,7 +257,7 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.15.0</version>
                 <configuration>
-                    <release>11</release>
+                    <release>21</release>
                 </configuration>
             </plugin>
             <plugin>


### PR DESCRIPTION
### Motivation
- Provide reusable JavaFX observable collection utilities for mapping and concatenation of lists.
- Centralize and modernize JavaFX dependency management by moving `openjfx.version` to the parent POM and adding required modules.
- Migrate from `javax.annotation` to `jakarta.annotation` and bump platform/tooling versions to support newer JDK/JavaFX setups.

### Description
- Added `org.phoenicis.javafx.collections.MappedList` which projects an `ObservableList<T>` to `ObservableList<S>` with a mapping function.
- Added `org.phoenicis.javafx.collections.ConcatenatedList` which exposes a single observable view concatenating multiple `ObservableList` sources and listens for source changes.
- Updated `phoenicis-javafx/pom.xml` to include `javafx-base` and `javafx-graphics` dependencies and removed the custom `javafx-collections` dependency, relying on the centralized `openjfx.version` instead.
- Added `openjfx.version` and JavaFX modules (`javafx-base`, `javafx-graphics`, `javafx-controls`, `javafx-web`, `javafx-media`) to the root `pom.xml` dependency management and bumped `spring.version` to `5.3.39`.
- Migrated `@PreDestroy` imports from `javax.annotation.PreDestroy` to `jakarta.annotation.PreDestroy` in `phoenicis-multithreading` sources and updated `phoenicis-multithreading/pom.xml` to use `jakarta.annotation-api:3.0.0`.
- Bumped the compiler target by changing the maven-compiler-plugin `<release>` from `11` to `21`.

### Testing
- Ran a full Maven build (`mvn -DskipTests=false verify`) to ensure compilation and dependency resolution after dependency and Java version changes, and the build completed successfully.
- Executed unit tests (`mvn test`) and the test suite passed under the updated dependencies and compiler settings.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a56e184b608326a563f2c288b56f93)