### PR TITLE
dist: include commons-logging in packaged dependencies

### DIFF
--- a/phoenicis-dist/pom.xml
+++ b/phoenicis-dist/pom.xml
@@ -54,7 +54,7 @@
                         <phase>package</phase>
                         <configuration>
                             <outputDirectory>${project.build.directory}/lib</outputDirectory>
-                            <excludeArtifactIds>bcprov-jdk16, bcmail-jdk16, bcpg-jdk16, commons-logging, xml-apis, xmlParserAPIs, xercesImpl, truffle-api, graal-sdk</excludeArtifactIds>
+                            <excludeArtifactIds>bcprov-jdk16, bcmail-jdk16, bcpg-jdk16, xml-apis, xmlParserAPIs, xercesImpl, truffle-api, graal-sdk</excludeArtifactIds>
                         </configuration>
                     </execution>
                     <execution>


### PR DESCRIPTION
### Motivation
- Spring fails to initialize at runtime with `NoClassDefFoundError: org/apache/commons/logging/LogFactory` because `commons-logging` was being excluded from the set of runtime jars copied into the distribution.

### Description
- Remove `commons-logging` from the `<excludeArtifactIds>` entry in `phoenicis-dist/pom.xml` so the `commons-logging` artifact will be copied into the distribution `lib` directory during the `package` phase.

### Testing
- Attempted dependency inspection via the Maven dependency plugin and a local validation with `mvn -o -pl phoenicis-dist -DskipTests validate`, but plugin/dependency resolution failed in this environment due to offline/repository access restrictions, so no successful Maven validation could be completed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a9330e88888326bdc15bac0231df2a)