### PR TITLE
ci: ignore unresolved commons-beanutils Dependabot alert

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,9 @@ updates:
       time: "07:00"
     open-pull-requests-limit: 10
     ignore:
+      # ignore commons-beanutils security alert updates because this project
+      # does not declare the dependency directly in pom manifests
+      - dependency-name: "commons-beanutils:commons-beanutils"
       # ignore all GraalVM updates (stick to 21.1.x)
       - dependency-name: "org.graalvm.sdk:graal-sdk"
         update-types: ["version-update:semver-major", "version-update:semver-minor"]


### PR DESCRIPTION
### Motivation
- Dependabot security updates were failing with `security_update_dependency_not_found` for `commons-beanutils:commons-beanutils` because the project does not declare that dependency directly in its Maven `pom.xml` manifests.

### Description
- Add an `ignore` entry to `.github/dependabot.yml` to skip `commons-beanutils:commons-beanutils` for the Maven ecosystem, preventing spurious security-update failures.

### Testing
- Successfully parsed the updated ` .github/dependabot.yml` using `ruby -e "require 'yaml'; YAML.load_file('.github/dependabot.yml')"`. 
- Attempted to parse with Python using `import yaml` but it failed due to the environment missing the `PyYAML` package, which does not affect the YAML file change itself.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a9446ed2e88326a78b93441902e1ce)