### PR TITLE
Handle null scripts in ApplicationInformationPanelSkin

### DIFF
--- a/phoenicis-javafx/src/main/java/org/phoenicis/javafx/components/application/skin/ApplicationInformationPanelSkin.java
+++ b/phoenicis-javafx/src/main/java/org/phoenicis/javafx/components/application/skin/ApplicationInformationPanelSkin.java
@@ -275,6 +275,10 @@ public class ApplicationInformationPanelSkin
     }
 
     private String sanitizeScript(String source) {
+        if (source == null) {
+            return "";
+        }
+
         return source.replaceAll(WINE_SOURCE_URL_PATTERN, PLAYONLINUX_WINE_BINARIES_URL);
     }
 

--- a/phoenicis-javafx/src/test/java/org/phoenicis/javafx/components/application/skin/ApplicationInformationPanelSkinSourceTest.java
+++ b/phoenicis-javafx/src/test/java/org/phoenicis/javafx/components/application/skin/ApplicationInformationPanelSkinSourceTest.java
@@ -18,4 +18,13 @@ public class ApplicationInformationPanelSkinSourceTest {
 
         assertTrue(content.contains("http://www.playonlinux.com/wine/binaries/"));
     }
+
+    @Test
+    public void testHandlesNullScripts() throws IOException {
+        final Path sourcePath = Path.of(
+                "src/main/java/org/phoenicis/javafx/components/application/skin/ApplicationInformationPanelSkin.java");
+        final String content = Files.readString(sourcePath, StandardCharsets.UTF_8);
+
+        assertTrue(content.contains("if (source == null)"));
+    }
 }


### PR DESCRIPTION
### Motivation
- Clicking the install button could trigger a JavaFX-thread `NullPointerException` when a repository script has no source payload, so the installer UI needs to tolerate null script content.

### Description
- Add a null guard to `sanitizeScript(String source)` in `phoenicis-javafx/src/main/java/org/phoenicis/javafx/components/application/skin/ApplicationInformationPanelSkin.java` so it returns an empty string when `source` is `null`.
- Preserve the existing URL-rewrite behavior (replace `WINE_SOURCE_URL_PATTERN` with `PLAYONLINUX_WINE_BINARIES_URL`) for non-null script content.
- Add a source-level regression test `testHandlesNullScripts` in `phoenicis-javafx/src/test/java/org/phoenicis/javafx/components/application/skin/ApplicationInformationPanelSkinSourceTest.java` to assert the null-guard remains present.

### Testing
- Attempted to run `mvn -pl phoenicis-javafx -Dtest=ApplicationInformationPanelSkinSourceTest test`, but the build failed due to an external plugin resolution error (Maven Central returned HTTP 403 for `net.revelc.code.formatter:formatter-maven-plugin:2.29.0`).
- The new test is present and would validate the source-level guard in a normal CI environment where dependencies can be resolved.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a9584a53ac8326a3962b54d1e788a4)