### PR TITLE
launcher: suppress Truffle warning noise on modern JDKs

### DIFF
--- a/phoenicis-dist/src/launchers/phoenicis
+++ b/phoenicis-dist/src/launchers/phoenicis
@@ -49,11 +49,16 @@ done
 
 JAVA_BIN="${JAVA_BIN:-java}"
 
-JVM_OPTS=()
+JVM_OPTS=("-Dpolyglot.engine.WarnInterpreterOnly=false")
 if "$JAVA_BIN" -XX:+UnlockExperimentalVMOptions -XX:+EnableJVMCI -version >/dev/null 2>&1; then
     JVM_OPTS+=("-XX:+UnlockExperimentalVMOptions" "-XX:+EnableJVMCI")
+fi
+
+NATIVE_ACCESS_OPTS=()
+if "$JAVA_BIN" "${JVM_OPTS[@]}" --enable-native-access=org.graalvm.truffle --enable-native-access=javafx.graphics,javafx.web -version >/dev/null 2>&1; then
+    NATIVE_ACCESS_OPTS+=("--enable-native-access=org.graalvm.truffle" "--enable-native-access=javafx.graphics,javafx.web")
 else
-    JVM_OPTS+=("-Dpolyglot.engine.WarnInterpreterOnly=false")
+    echo "Skipping native-access flags: JVM does not support --enable-native-access." >&2
 fi
 
 LIB_DIR="$APP_HOME/lib"
@@ -72,7 +77,6 @@ fi
 
 JAVA_FX_MODULE_OPTS=(
     --add-modules=javafx.base,javafx.web,javafx.media,javafx.graphics,javafx.controls
-    --enable-native-access=javafx.graphics,javafx.web
     --module-path "$MODULE_PATH"
 )
 
@@ -98,6 +102,7 @@ fi
 if compgen -G "$APP_DIR/phoenicis-javafx-*.jar" > /dev/null || compgen -G "$LIB_DIR/phoenicis-javafx-*.jar" > /dev/null; then
     launch_args=(
         "${JVM_OPTS[@]}"
+        "${NATIVE_ACCESS_OPTS[@]}"
         "${JAVA_FX_MODULE_OPTS[@]}"
         "${COMPILER_OPTS[@]}"
         -cp "$APP_DIR/*:$LIB_DIR/*"
@@ -113,7 +118,7 @@ if compgen -G "$APP_DIR/phoenicis-javafx-*.jar" > /dev/null || compgen -G "$LIB_
         echo "JavaFX modular startup failed, retrying with classpath-only JavaFX fallback." >&2
 
         fallback_log="$(mktemp)"
-        if "$JAVA_BIN" "${JVM_OPTS[@]}" "${COMPILER_OPTS[@]}" -cp "$APP_DIR/*:$LIB_DIR/*" org.phoenicis.javafx.PhoenicisLauncher "$@" 2>"$fallback_log"; then
+        if "$JAVA_BIN" "${JVM_OPTS[@]}" "${NATIVE_ACCESS_OPTS[@]}" "${COMPILER_OPTS[@]}" -cp "$APP_DIR/*:$LIB_DIR/*" org.phoenicis.javafx.PhoenicisLauncher "$@" 2>"$fallback_log"; then
             rm -f "$fallback_log"
             exit 0
         fi


### PR DESCRIPTION
### Motivation
- Reduce noisy Graal/Truffle fallback warnings and Unsafe/native-access warnings emitted at startup on modern JDKs.
- Enable native access to Truffle and JavaFX only when the JVM supports it to avoid spurious warnings while keeping backward compatibility.

### Description
- Always add `-Dpolyglot.engine.WarnInterpreterOnly=false` to `JVM_OPTS` so the interpreter-only fallback warning is suppressed consistently.
- Preserve JVMCI detection and append `-XX:+UnlockExperimentalVMOptions` and `-XX:+EnableJVMCI` when available by probing the `java` binary.
- Probe for support of `--enable-native-access` and, when supported, add `--enable-native-access=org.graalvm.truffle` and `--enable-native-access=javafx.graphics,javafx.web` to a new `NATIVE_ACCESS_OPTS` array.
- Apply `NATIVE_ACCESS_OPTS` to both the modular JavaFX startup path and the classpath fallback path, and print a clear message when the JVM does not support `--enable-native-access`.

### Testing
- Performed a shell syntax check with `bash -n phoenicis-dist/src/launchers/phoenicis`, which succeeded.
- Inspected the updated launcher to confirm the new `JVM_OPTS` and `NATIVE_ACCESS_OPTS` are included in both modular and fallback launch paths.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a95c0c62ac83269f0d9eb54868387b)