### PR TITLE
Avoid network I/O in miniature merging to prevent repository fetch hangs

### DIFF
--- a/phoenicis-repository/src/main/java/org/phoenicis/repository/types/MergeableRepository.java
+++ b/phoenicis-repository/src/main/java/org/phoenicis/repository/types/MergeableRepository.java
@@ -3,21 +3,15 @@
  */
 package org.phoenicis.repository.types;
 
-import org.apache.commons.codec.digest.DigestUtils;
 import org.phoenicis.configuration.localisation.Localisation;
 import org.phoenicis.configuration.localisation.PropertiesResourceBundle;
 import org.phoenicis.repository.dto.*;
-import org.slf4j.LoggerFactory;
 
-import java.io.IOException;
-import java.io.InputStream;
 import java.net.URI;
 import java.util.*;
 import java.util.function.Function;
 
 abstract class MergeableRepository implements Repository {
-    private final static org.slf4j.Logger LOGGER = LoggerFactory.getLogger(MergeableRepository.class);
-
     /**
      * This method merges multiple application sources into a single list of
      * category dtos. For this it receives a map, containing a binding between
@@ -178,7 +172,7 @@ abstract class MergeableRepository implements Repository {
      *         <code>rightMiniatures</code>
      */
     protected List<URI> mergeMiniatures(List<URI> leftMiniatures, List<URI> rightMiniatures) {
-        HashMap<String, URI> mergedMiniatures = new HashMap<>();
+        final Map<String, URI> mergedMiniatures = new LinkedHashMap<>();
 
         /*
          * Concatenate the both lists with the left list in front of the right one
@@ -190,13 +184,8 @@ abstract class MergeableRepository implements Repository {
          * Remove duplicates
          */
         for (URI miniatureUri : miniatures) {
-            try (InputStream inputStream = miniatureUri.toURL().openStream()) {
-                String checksum = DigestUtils.md5Hex(inputStream);
-                if (!mergedMiniatures.containsKey(checksum)) {
-                    mergedMiniatures.put(checksum, miniatureUri);
-                }
-            } catch (IOException e) {
-                LOGGER.error(String.format("Couldn't merge miniatures at %s", miniatureUri.toString()), e);
+            if (miniatureUri != null) {
+                mergedMiniatures.putIfAbsent(miniatureUri.normalize().toString(), miniatureUri);
             }
         }
 

--- a/phoenicis-repository/src/test/java/org/phoenicis/repository/types/MultipleRepositoryTest.java
+++ b/phoenicis-repository/src/test/java/org/phoenicis/repository/types/MultipleRepositoryTest.java
@@ -23,6 +23,7 @@ import org.junit.Test;
 import org.phoenicis.repository.dto.RepositoryDTO;
 import org.phoenicis.repository.dto.TypeDTO;
 
+import java.net.URI;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -30,6 +31,17 @@ import java.util.List;
 import static org.junit.Assert.assertEquals;
 
 public class MultipleRepositoryTest {
+    private static class ExposedMergeableRepository extends MergeableRepository {
+        @Override
+        public RepositoryDTO fetchInstallableApplications() {
+            return null;
+        }
+
+        List<URI> mergeMiniaturesForTest(List<URI> leftMiniatures, List<URI> rightMiniatures) {
+            return mergeMiniatures(leftMiniatures, rightMiniatures);
+        }
+    }
+
     @Test
     public void testWithEmptyListEmptySetIsReturned() {
         final MultipleRepository multipleRepository = new MultipleRepository();
@@ -83,5 +95,21 @@ public class MultipleRepositoryTest {
 
         assertEquals(1, multipleRepository.size());
         assertEquals(1, multipleRepository.fetchInstallableApplications().getTypes().get(0).getCategories().size());
+    }
+
+    @Test
+    public void testMergeMiniaturesRemovesDuplicateUrisAndPreservesPriority() {
+        final ExposedMergeableRepository mergeableRepository = new ExposedMergeableRepository();
+
+        final URI leftUri = URI.create("https://example.invalid/same-image.png");
+        final URI rightUniqueUri = URI.create("https://example.invalid/other-image.png");
+
+        final List<URI> result = mergeableRepository.mergeMiniaturesForTest(
+                Collections.singletonList(leftUri),
+                java.util.Arrays.asList(leftUri, rightUniqueUri));
+
+        assertEquals(2, result.size());
+        assertEquals(leftUri, result.get(0));
+        assertEquals(rightUniqueUri, result.get(1));
     }
 }


### PR DESCRIPTION
### Motivation
- Repository fetch could block while computing checksums for miniatures by opening remote streams, causing the UI to hang when fetching application data (e.g. during installs like 7-zip). 
- Deduplication should be non-blocking and preserve the priority of the left-side miniature list.

### Description
- Rewrote `mergeMiniatures` in `MergeableRepository` to stop opening network streams and computing checksums, and instead deduplicate by the normalized URI string while preserving insertion order using a `LinkedHashMap` and `putIfAbsent`.
- Removed unused checksum/stream/logging imports that were only needed for the previous streaming/checksum approach.
- Added a test helper `ExposedMergeableRepository` and `testMergeMiniaturesRemovesDuplicateUrisAndPreservesPriority` in `MultipleRepositoryTest` to verify duplicate removal and left-side priority is preserved.

### Testing
- Added unit test `testMergeMiniaturesRemovesDuplicateUrisAndPreservesPriority` under `phoenicis-repository` to validate behavior of `mergeMiniatures`.
- Attempted to run `mvn -pl phoenicis-repository -Dtest=MultipleRepositoryTest test`, which could not complete in this environment due to Maven plugin/dependency resolution failing with HTTP 403 from Maven Central (plugin resolution issue), so tests were not executed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b30f6f969c8326aa52fa5499e1deb3)