### PR TITLE
Add configurable HTTP timeouts and simplify miniature deduplication

### DIFF
--- a/phoenicis-repository/src/main/java/org/phoenicis/repository/types/MergeableRepository.java
+++ b/phoenicis-repository/src/main/java/org/phoenicis/repository/types/MergeableRepository.java
@@ -3,21 +3,15 @@
  */
 package org.phoenicis.repository.types;
 
-import org.apache.commons.codec.digest.DigestUtils;
 import org.phoenicis.configuration.localisation.Localisation;
 import org.phoenicis.configuration.localisation.PropertiesResourceBundle;
 import org.phoenicis.repository.dto.*;
-import org.slf4j.LoggerFactory;
 
-import java.io.IOException;
-import java.io.InputStream;
 import java.net.URI;
 import java.util.*;
 import java.util.function.Function;
 
 abstract class MergeableRepository implements Repository {
-    private final static org.slf4j.Logger LOGGER = LoggerFactory.getLogger(MergeableRepository.class);
-
     /**
      * This method merges multiple application sources into a single list of
      * category dtos. For this it receives a map, containing a binding between
@@ -178,7 +172,7 @@ abstract class MergeableRepository implements Repository {
      *         <code>rightMiniatures</code>
      */
     protected List<URI> mergeMiniatures(List<URI> leftMiniatures, List<URI> rightMiniatures) {
-        HashMap<String, URI> mergedMiniatures = new HashMap<>();
+        final Map<String, URI> mergedMiniatures = new LinkedHashMap<>();
 
         /*
          * Concatenate the both lists with the left list in front of the right one
@@ -190,13 +184,8 @@ abstract class MergeableRepository implements Repository {
          * Remove duplicates
          */
         for (URI miniatureUri : miniatures) {
-            try (InputStream inputStream = miniatureUri.toURL().openStream()) {
-                String checksum = DigestUtils.md5Hex(inputStream);
-                if (!mergedMiniatures.containsKey(checksum)) {
-                    mergedMiniatures.put(checksum, miniatureUri);
-                }
-            } catch (IOException e) {
-                LOGGER.error(String.format("Couldn't merge miniatures at %s", miniatureUri.toString()), e);
+            if (miniatureUri != null) {
+                mergedMiniatures.putIfAbsent(miniatureUri.normalize().toString(), miniatureUri);
             }
         }
 

--- a/phoenicis-repository/src/test/java/org/phoenicis/repository/types/MultipleRepositoryTest.java
+++ b/phoenicis-repository/src/test/java/org/phoenicis/repository/types/MultipleRepositoryTest.java
@@ -23,6 +23,7 @@ import org.junit.Test;
 import org.phoenicis.repository.dto.RepositoryDTO;
 import org.phoenicis.repository.dto.TypeDTO;
 
+import java.net.URI;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -30,6 +31,17 @@ import java.util.List;
 import static org.junit.Assert.assertEquals;
 
 public class MultipleRepositoryTest {
+    private static class ExposedMergeableRepository extends MergeableRepository {
+        @Override
+        public RepositoryDTO fetchInstallableApplications() {
+            return null;
+        }
+
+        List<URI> mergeMiniaturesForTest(List<URI> leftMiniatures, List<URI> rightMiniatures) {
+            return mergeMiniatures(leftMiniatures, rightMiniatures);
+        }
+    }
+
     @Test
     public void testWithEmptyListEmptySetIsReturned() {
         final MultipleRepository multipleRepository = new MultipleRepository();
@@ -83,5 +95,21 @@ public class MultipleRepositoryTest {
 
         assertEquals(1, multipleRepository.size());
         assertEquals(1, multipleRepository.fetchInstallableApplications().getTypes().get(0).getCategories().size());
+    }
+
+    @Test
+    public void testMergeMiniaturesRemovesDuplicateUrisAndPreservesPriority() {
+        final ExposedMergeableRepository mergeableRepository = new ExposedMergeableRepository();
+
+        final URI leftUri = URI.create("https://example.invalid/same-image.png");
+        final URI rightUniqueUri = URI.create("https://example.invalid/other-image.png");
+
+        final List<URI> result = mergeableRepository.mergeMiniaturesForTest(
+                Collections.singletonList(leftUri),
+                java.util.Arrays.asList(leftUri, rightUniqueUri));
+
+        assertEquals(2, result.size());
+        assertEquals(leftUri, result.get(0));
+        assertEquals(rightUniqueUri, result.get(1));
     }
 }

--- a/phoenicis-tools/src/main/java/org/phoenicis/tools/http/PhoenicisUrlConnection.java
+++ b/phoenicis-tools/src/main/java/org/phoenicis/tools/http/PhoenicisUrlConnection.java
@@ -10,6 +10,11 @@ import java.util.Map;
  * Wrapper around {@link HttpURLConnection class} that follows correctly HTTP redirects
  */
 class PhoenicisUrlConnection {
+    static final String CONNECT_TIMEOUT_PROPERTY = "phoenicis.http.connectTimeout.ms";
+    static final String READ_TIMEOUT_PROPERTY = "phoenicis.http.readTimeout.ms";
+    static final int DEFAULT_CONNECT_TIMEOUT_MS = 10000;
+    static final int DEFAULT_READ_TIMEOUT_MS = 30000;
+
     private Integer responseCode;
     private HttpURLConnection delegateUrlConnection;
     private URL url;
@@ -36,12 +41,34 @@ class PhoenicisUrlConnection {
      * @throws IOException if any IO Error happens
      */
     static PhoenicisUrlConnection fromURL(URL url) throws IOException {
-        final HttpURLConnection connection = (HttpURLConnection) url.openConnection();
-        connection.setInstanceFollowRedirects(false);
+        final HttpURLConnection connection = openConnection(url);
 
         return new PhoenicisUrlConnection(
                 connection,
                 url);
+    }
+
+    private static HttpURLConnection openConnection(URL url) throws IOException {
+        final HttpURLConnection connection = (HttpURLConnection) url.openConnection();
+        connection.setInstanceFollowRedirects(false);
+        connection.setConnectTimeout(resolveTimeout(CONNECT_TIMEOUT_PROPERTY, DEFAULT_CONNECT_TIMEOUT_MS));
+        connection.setReadTimeout(resolveTimeout(READ_TIMEOUT_PROPERTY, DEFAULT_READ_TIMEOUT_MS));
+        return connection;
+    }
+
+    static int resolveTimeout(String propertyName, int defaultValue) {
+        final String configuredValue = System.getProperty(propertyName);
+
+        if (configuredValue == null || configuredValue.trim().isEmpty()) {
+            return defaultValue;
+        }
+
+        try {
+            final int timeout = Integer.parseInt(configuredValue.trim());
+            return timeout > 0 ? timeout : defaultValue;
+        } catch (NumberFormatException e) {
+            return defaultValue;
+        }
     }
 
     /**
@@ -142,8 +169,7 @@ class PhoenicisUrlConnection {
         if (responseCode == 302 || responseCode == 301) {
             final String redirectLocation = delegateUrlConnection.getHeaderField("Location");
             this.url = new URL(redirectLocation);
-            this.delegateUrlConnection = (HttpURLConnection) url.openConnection();
-            this.delegateUrlConnection.setInstanceFollowRedirects(false);
+            this.delegateUrlConnection = openConnection(url);
             this.responseCode = null;
             if (this.headers != null) {
                 setHeaders(headers);

--- a/phoenicis-tools/src/test/java/org/phoenicis/tools/http/PhoenicisUrlConnectionTest.java
+++ b/phoenicis-tools/src/test/java/org/phoenicis/tools/http/PhoenicisUrlConnectionTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (C) 2015-2017 PÂRIS Quentin
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+package org.phoenicis.tools.http;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class PhoenicisUrlConnectionTest {
+    @Test
+    public void testResolveTimeoutUsesDefaultWhenPropertyMissing() {
+        System.clearProperty(PhoenicisUrlConnection.CONNECT_TIMEOUT_PROPERTY);
+
+        assertEquals(42, PhoenicisUrlConnection.resolveTimeout(
+                PhoenicisUrlConnection.CONNECT_TIMEOUT_PROPERTY,
+                42));
+    }
+
+    @Test
+    public void testResolveTimeoutUsesConfiguredValueWhenValid() {
+        System.setProperty(PhoenicisUrlConnection.READ_TIMEOUT_PROPERTY, "1234");
+
+        assertEquals(1234, PhoenicisUrlConnection.resolveTimeout(
+                PhoenicisUrlConnection.READ_TIMEOUT_PROPERTY,
+                42));
+
+        System.clearProperty(PhoenicisUrlConnection.READ_TIMEOUT_PROPERTY);
+    }
+
+    @Test
+    public void testResolveTimeoutFallsBackToDefaultWhenInvalid() {
+        System.setProperty(PhoenicisUrlConnection.CONNECT_TIMEOUT_PROPERTY, "invalid");
+        assertEquals(42, PhoenicisUrlConnection.resolveTimeout(
+                PhoenicisUrlConnection.CONNECT_TIMEOUT_PROPERTY,
+                42));
+
+        System.setProperty(PhoenicisUrlConnection.CONNECT_TIMEOUT_PROPERTY, "0");
+        assertEquals(42, PhoenicisUrlConnection.resolveTimeout(
+                PhoenicisUrlConnection.CONNECT_TIMEOUT_PROPERTY,
+                42));
+
+        System.setProperty(PhoenicisUrlConnection.CONNECT_TIMEOUT_PROPERTY, "-1");
+        assertEquals(42, PhoenicisUrlConnection.resolveTimeout(
+                PhoenicisUrlConnection.CONNECT_TIMEOUT_PROPERTY,
+                42));
+
+        System.clearProperty(PhoenicisUrlConnection.CONNECT_TIMEOUT_PROPERTY);
+    }
+}


### PR DESCRIPTION
### Motivation

- Make HTTP connections configurable and resilient to slow hosts by adding connect/read timeout support and sane defaults. 
- Remove expensive I/O and checksum dependency from miniature merging to avoid opening streams for each URI and to preserve insertion priority.

### Description

- Added `CONNECT_TIMEOUT_PROPERTY`, `READ_TIMEOUT_PROPERTY`, `DEFAULT_CONNECT_TIMEOUT_MS`, `DEFAULT_READ_TIMEOUT_MS`, and a `resolveTimeout` helper to `PhoenicisUrlConnection` and applied resolved timeouts when opening connections via a new `openConnection` helper used by `fromURL` and redirect handling. 
- Modified redirect handling in `PhoenicisUrlConnection` to reuse `openConnection` so timeouts and `setInstanceFollowRedirects(false)` are consistently applied. 
- Simplified `mergeMiniatures` in `MergeableRepository` to deduplicate by normalized URI string using a `LinkedHashMap` (preserving priority/order) and removed the MD5 checksum, stream-opening logic, commons-codec dependency, and SLF4J logger usage. 
- Added unit tests: `PhoenicisUrlConnectionTest` covering `resolveTimeout` behavior and an extended `MultipleRepositoryTest` case `testMergeMiniaturesRemovesDuplicateUrisAndPreservesPriority` which exercises the new `mergeMiniatures` behavior.

### Testing

- Ran unit tests for the modified components: `PhoenicisUrlConnectionTest` and `MultipleRepositoryTest`, and they passed. 
- Existing repository unit tests were exercised and reported no failures after the changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b30f6f969c8326aa52fa5499e1deb3)