### PR TITLE
Harden local file loading and opener command validation

### DIFF
--- a/phoenicis-cli/src/main/java/org/phoenicis/cli/CLIConfiguration.java
+++ b/phoenicis-cli/src/main/java/org/phoenicis/cli/CLIConfiguration.java
@@ -31,9 +31,9 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 
 @Configuration
-@Import({PhoenicisGlobalConfiguration.class, ScriptsConfiguration.class, RepositoryConfiguration.class,
+@Import({ PhoenicisGlobalConfiguration.class, ScriptsConfiguration.class, RepositoryConfiguration.class,
         EnginesConfiguration.class, LibraryConfiguration.class, Win32Configuration.class, ToolsConfiguration.class,
-        MultithreadingConfiguration.class, CliUiConfiguration.class})
+        MultithreadingConfiguration.class, CliUiConfiguration.class })
 class CLIConfiguration {
 
 }

--- a/phoenicis-javafx/src/main/java/org/phoenicis/javafx/AppConfiguration.java
+++ b/phoenicis-javafx/src/main/java/org/phoenicis/javafx/AppConfiguration.java
@@ -37,7 +37,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 
 @Configuration
-@Import({PhoenicisGlobalConfiguration.class,
+@Import({ PhoenicisGlobalConfiguration.class,
         ControllerConfiguration.class,
         ScriptsConfiguration.class,
         ThemeConfiguration.class,

--- a/phoenicis-javafx/src/main/java/org/phoenicis/javafx/controller/apps/AppsController.java
+++ b/phoenicis-javafx/src/main/java/org/phoenicis/javafx/controller/apps/AppsController.java
@@ -89,7 +89,8 @@ public class AppsController {
             try {
                 StringBuilder cssBuilder = new StringBuilder();
                 for (CategoryDTO category : categories) {
-                    cssBuilder.append("#").append(ApplicationSidebarToggleGroupSkin.getToggleButtonId(category.getId())).append("{\n");
+                    cssBuilder.append("#").append(ApplicationSidebarToggleGroupSkin.getToggleButtonId(category.getId()))
+                            .append("{\n");
                     final String categoryIconPath = Optional.ofNullable(category.getIcon())
                             .map(categoryIcon -> categoryIcon.toString())
                             .orElse("/org/phoenicis/javafx/views/common/phoenicis.png");

--- a/phoenicis-javafx/src/main/java/org/phoenicis/javafx/controller/engines/EnginesController.java
+++ b/phoenicis-javafx/src/main/java/org/phoenicis/javafx/controller/engines/EnginesController.java
@@ -191,8 +191,8 @@ public class EnginesController {
                 .collect(Collectors.toList());
 
         Platform.runLater(() ->
-            // generate the necessary css for the engine categories
-            setDefaultEngineIcons(categoryDTOS));
+        // generate the necessary css for the engine categories
+        setDefaultEngineIcons(categoryDTOS));
 
         // fetch the engine categories objects contained in the engine categories
         final Queue<EngineCategoryDTO> engineCategories = new ArrayDeque<>(
@@ -207,8 +207,8 @@ public class EnginesController {
                     .collect(Collectors.toList());
 
             Platform.runLater(() ->
-                // update the view
-                enginesView.populate(categories, engines));
+            // update the view
+            enginesView.populate(categories, engines));
         });
     }
 
@@ -234,13 +234,13 @@ public class EnginesController {
             enginesManager.fetchAvailableVersions(
                     engineId,
                     versions ->
-                        // recursively process the remaining engine categories
-                        fetchEngineSubcategories(queue,
-                                ImmutableMap.<EngineCategoryDTO, List<EngineSubCategoryDTO>> builder()
-                                        .putAll(result)
-                                        .put(engineCategory, versions)
-                                        .build(),
-                                callback),
+                    // recursively process the remaining engine categories
+                    fetchEngineSubcategories(queue,
+                            ImmutableMap.<EngineCategoryDTO, List<EngineSubCategoryDTO>> builder()
+                                    .putAll(result)
+                                    .put(engineCategory, versions)
+                                    .build(),
+                            callback),
                     e -> Platform.runLater(() -> {
                         final ErrorDialog errorDialog = ErrorDialog.builder()
                                 .withMessage(tr("Error"))

--- a/phoenicis-javafx/src/main/java/org/phoenicis/javafx/controller/library/LibraryController.java
+++ b/phoenicis-javafx/src/main/java/org/phoenicis/javafx/controller/library/LibraryController.java
@@ -98,7 +98,8 @@ public class LibraryController {
             try {
                 StringBuilder cssBuilder = new StringBuilder();
                 for (ShortcutCategoryDTO category : categories) {
-                    cssBuilder.append("#").append(LibrarySidebarToggleGroupSkin.getToggleButtonId(category.getId())).append("{\n");
+                    cssBuilder.append("#").append(LibrarySidebarToggleGroupSkin.getToggleButtonId(category.getId()))
+                            .append("{\n");
                     final String categoryIconPath = Optional.ofNullable(category.getIcon())
                             .map(categoryIcon -> categoryIcon.toString())
                             .orElse("/org/phoenicis/javafx/views/common/phoenicis.png");

--- a/phoenicis-repository/src/main/java/org/phoenicis/repository/DefaultRepositoryManager.java
+++ b/phoenicis-repository/src/main/java/org/phoenicis/repository/DefaultRepositoryManager.java
@@ -175,8 +175,10 @@ public class DefaultRepositoryManager implements RepositoryManager {
     @Override
     public synchronized void triggerCallbacks() {
         if (!this.callbacks.isEmpty()) {
-            this.backgroundRepository.fetchInstallableApplications(repositoryDTO ->
-                this.callbacks.forEach(callbackPair -> callbackPair.getOnRepositoryChange().accept(tr(repositoryDTO))), exception -> this.callbacks.forEach(callbackPair -> callbackPair.getOnError().accept(exception)));
+            this.backgroundRepository.fetchInstallableApplications(
+                    repositoryDTO -> this.callbacks
+                            .forEach(callbackPair -> callbackPair.getOnRepositoryChange().accept(tr(repositoryDTO))),
+                    exception -> this.callbacks.forEach(callbackPair -> callbackPair.getOnError().accept(exception)));
             // do not set this in triggerRepositoryChange()
             // if no callbacks are registered, fetchInstallableApplications is not called and the repository is not
             // loaded

--- a/phoenicis-repository/src/main/java/org/phoenicis/repository/FilesystemJsonRepositoryLocationLoader.java
+++ b/phoenicis-repository/src/main/java/org/phoenicis/repository/FilesystemJsonRepositoryLocationLoader.java
@@ -61,7 +61,7 @@ public class FilesystemJsonRepositoryLocationLoader implements RepositoryLocatio
 
         if (repositoryListFile.exists()) {
             try {
-                result = this.objectMapper.readValue(new File(repositoryListPath),
+                result = this.objectMapper.readValue(repositoryListFile,
                         TypeFactory.defaultInstance().constructParametricType(List.class, RepositoryLocation.class));
             } catch (IOException e) {
                 LOGGER.error("Couldn't load repository location list", e);
@@ -76,7 +76,7 @@ public class FilesystemJsonRepositoryLocationLoader implements RepositoryLocatio
     @Override
     public void saveRepositories(List<RepositoryLocation<? extends Repository>> repositoryLocations) {
         try {
-            objectMapper.writeValue(new File(repositoryListPath), repositoryLocations);
+            objectMapper.writeValue(new File(repositoryListPath).getAbsoluteFile(), repositoryLocations);
         } catch (IOException e) {
             LOGGER.error("Couldn't save repository location list", e);
         }

--- a/phoenicis-repository/src/main/java/org/phoenicis/repository/types/LocalRepository.java
+++ b/phoenicis-repository/src/main/java/org/phoenicis/repository/types/LocalRepository.java
@@ -34,7 +34,11 @@ import org.slf4j.LoggerFactory;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.net.URI;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.Files;
 import java.util.*;
 import java.util.stream.Collectors;
 
@@ -258,7 +262,7 @@ public final class LocalRepository implements Repository {
             if (!resourceFile.isDirectory() && !resourceFile.getName().startsWith(".")) {
                 try {
                     results.add(new ResourceDTO(resourceFile.getName(),
-                            IOUtils.toByteArray(new FileInputStream(resourceFile))));
+                            readFileBytes(resourceFile))));
                 } catch (IOException ignored) {
 
                 }
@@ -312,7 +316,7 @@ public final class LocalRepository implements Repository {
 
                 if (scriptFile.exists()) {
                     try {
-                        scriptDTOBuilder.withScript(new String(IOUtils.toByteArray(new FileInputStream(scriptFile))));
+                        scriptDTOBuilder.withScript(new String(readFileBytes(scriptFile)));
                     } catch (IOException e) {
                         LOGGER.warn("Script not found", e);
                     }
@@ -331,6 +335,17 @@ public final class LocalRepository implements Repository {
         }
 
         return results;
+    }
+
+    private byte[] readFileBytes(File file) throws IOException {
+        final Path repositoryPath = repositoryDirectory.toPath().toAbsolutePath().normalize();
+        final Path candidatePath = file.toPath().toAbsolutePath().normalize();
+
+        if (!candidatePath.startsWith(repositoryPath) || !Files.isRegularFile(candidatePath)) {
+            throw new IOException("Refusing to read file outside repository directory: " + candidatePath);
+        }
+
+        return Files.readAllBytes(candidatePath);
     }
 
     private TypeDTO unSerializeType(File jsonFile) {

--- a/phoenicis-scripts/src/main/java/org/phoenicis/scripts/interpreter/BackgroundScriptInterpreter.java
+++ b/phoenicis-scripts/src/main/java/org/phoenicis/scripts/interpreter/BackgroundScriptInterpreter.java
@@ -47,14 +47,13 @@ public class BackgroundScriptInterpreter implements ScriptInterpreter {
     public InteractiveScriptSession createInteractiveSession() {
         final InteractiveScriptSession interactiveScriptSession = delegated.createInteractiveSession();
 
-        return (evaluation, responseCallback, errorCallback) ->
-            executorService.execute(() -> {
-                try {
-                    interactiveScriptSession.eval(evaluation, responseCallback, errorCallback);
-                } catch (Throwable throwable) {
-                    errorCallback.accept(asException(throwable));
-                }
-            });
+        return (evaluation, responseCallback, errorCallback) -> executorService.execute(() -> {
+            try {
+                interactiveScriptSession.eval(evaluation, responseCallback, errorCallback);
+            } catch (Throwable throwable) {
+                errorCallback.accept(asException(throwable));
+            }
+        });
     }
 
     private Exception asException(Throwable throwable) {

--- a/phoenicis-scripts/src/test/java/org/phoenicis/scripts/engine/ScriptEngineTypeTest.java
+++ b/phoenicis-scripts/src/test/java/org/phoenicis/scripts/engine/ScriptEngineTypeTest.java
@@ -12,8 +12,8 @@ public class ScriptEngineTypeTest {
     public void shouldSupportConstDeclarationsInEvaluatedScripts() {
         final PhoenicisScriptEngine scriptEngine = ScriptEngineType.GRAAL.createScriptEngine();
 
-        final Value result = (Value) scriptEngine.evalAndReturn("const answer = 42; answer;", exception ->
-            fail(exception.getMessage()));
+        final Value result = (Value) scriptEngine.evalAndReturn("const answer = 42; answer;",
+                exception -> fail(exception.getMessage()));
 
         assertEquals(42, result.asInt());
     }

--- a/phoenicis-tools/src/main/java/org/phoenicis/tools/files/FileUtilities.java
+++ b/phoenicis-tools/src/main/java/org/phoenicis/tools/files/FileUtilities.java
@@ -304,15 +304,15 @@ public class FileUtilities extends FilesManipulator {
     private Set<PosixFilePermission> singleIntToFilePermission(Integer mode, String groupType) {
         Set<PosixFilePermission> permissions = new HashSet<>(9);
 
-        if (Arrays.asList( 1, 3, 5, 7).contains(mode)) {
+        if (Arrays.asList(1, 3, 5, 7).contains(mode)) {
             permissions.add(PosixFilePermission.valueOf(groupType + "_EXECUTE"));
         }
 
-        if (Arrays.asList( 2, 3, 6, 7).contains(mode)) {
+        if (Arrays.asList(2, 3, 6, 7).contains(mode)) {
             permissions.add(PosixFilePermission.valueOf(groupType + "_WRITE"));
         }
 
-        if (Arrays.asList( 4, 5, 6, 7).contains(mode)) {
+        if (Arrays.asList(4, 5, 6, 7).contains(mode)) {
             permissions.add(PosixFilePermission.valueOf(groupType + "_READ"));
         }
 

--- a/phoenicis-tools/src/main/java/org/phoenicis/tools/system/opener/OpenerProcessImplementation.java
+++ b/phoenicis-tools/src/main/java/org/phoenicis/tools/system/opener/OpenerProcessImplementation.java
@@ -21,15 +21,24 @@ package org.phoenicis.tools.system.opener;
 import org.phoenicis.configuration.security.Safe;
 
 import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.InvalidPathException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
 
 @Safe
 public class OpenerProcessImplementation implements Opener {
+    private static final Set<String> ALLOWED_COMMANDS = new HashSet<>(Arrays.asList("xdg-open", "open", "gio"));
     private final String commandName;
 
     public OpenerProcessImplementation(String commandName) {
+        if (!ALLOWED_COMMANDS.contains(commandName)) {
+            throw new IllegalArgumentException("Unsupported opener command: " + commandName);
+        }
+
         this.commandName = commandName;
     }
 
@@ -46,7 +55,10 @@ public class OpenerProcessImplementation implements Opener {
 
     private String sanitizePath(String file) {
         try {
-            final Path candidate = Paths.get(file).normalize();
+            final Path candidate = Paths.get(file).toAbsolutePath().normalize();
+            if (!Files.exists(candidate)) {
+                throw new IllegalArgumentException("File does not exist: " + candidate);
+            }
             return candidate.toString();
         } catch (InvalidPathException e) {
             throw new IllegalArgumentException("Invalid file path", e);


### PR DESCRIPTION
### Motivation
- Fix critical dynamic file/path access issues in repository loading that could allow reading files outside the configured repository. 
- Mitigate command-injection or misuse risk when launching external opener utilities with user-provided paths. 
- Reduce fragile file handling by using normalized paths and stronger validation before I/O or process invocation.

### Description
- Added a guarded helper `readFileBytes(File)` to `LocalRepository` that normalizes the requested path, enforces that it is under the configured repository directory, and verifies it is a regular file before reading via `Files.readAllBytes(...)`.
- Replaced direct `FileInputStream`/`IOUtils` reads for script and resource contents in `LocalRepository` with calls to `readFileBytes(...)` to centralize and enforce path validation.
- Tightened `OpenerProcessImplementation` by adding an allowlist `ALLOWED_COMMANDS` (`xdg-open`, `open`, `gio`) and validating that the supplied path is normalized, absolute and exists before calling `ProcessBuilder`.
- Simplified `FilesystemJsonRepositoryLocationLoader` to deserialize from the resolved `repositoryListFile` and write using the absolute file to avoid redundant `new File(repositoryListPath)` construction.

### Testing
- Ran `mvn -pl phoenicis-tools,phoenicis-repository -DskipTests compile` to verify compilation, which failed in this environment due to external dependency resolution errors from `jitpack.io` returning HTTP 403 (environmental issue), so module-level compile could not be fully validated here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1b65ecc1483268636a135fbe20957)