### PR TITLE
Avoid mocking final CategoryDTO in BackgroundRepositoryTest

### DIFF
--- a/phoenicis-repository/src/test/java/org/phoenicis/repository/types/BackgroundRepositoryTest.java
+++ b/phoenicis-repository/src/test/java/org/phoenicis/repository/types/BackgroundRepositoryTest.java
@@ -38,7 +38,8 @@ public class BackgroundRepositoryTest {
             new TypeDTO.Builder().withId("Type 1")
                     .withCategories(Arrays.asList(
                             new CategoryDTO.Builder().withTypeId("Type 1").withId("cat1").build(),
-                            new CategoryDTO.Builder().withTypeId("Type 1").withId("cat2").build())).build()))
+                            new CategoryDTO.Builder().withTypeId("Type 1").withId("cat2").build()))
+                    .build()))
             .build();
 
     @Test

--- a/phoenicis-repository/src/test/java/org/phoenicis/repository/types/BackgroundRepositoryTest.java
+++ b/phoenicis-repository/src/test/java/org/phoenicis/repository/types/BackgroundRepositoryTest.java
@@ -36,7 +36,9 @@ public class BackgroundRepositoryTest {
     private final BackgroundRepository backgroundRepository = new BackgroundRepository(mockRepository, mockExecutor);
     private final RepositoryDTO mockResults = new RepositoryDTO.Builder().withTypes(Collections.singletonList(
             new TypeDTO.Builder().withId("Type 1")
-                    .withCategories(Arrays.asList(mock(CategoryDTO.class), mock(CategoryDTO.class))).build()))
+                    .withCategories(Arrays.asList(
+                            new CategoryDTO.Builder().withTypeId("Type 1").withId("cat1").build(),
+                            new CategoryDTO.Builder().withTypeId("Type 1").withId("cat2").build())).build()))
             .build();
 
     @Test


### PR DESCRIPTION
### Motivation
- The test failed because Mockito cannot mock the `final` class `CategoryDTO`, causing `BackgroundRepositoryTest` to error during execution.

### Description
- Update `BackgroundRepositoryTest` to construct real `CategoryDTO` instances via `CategoryDTO.Builder` instead of calling `mock(CategoryDTO.class)`, preserving the original test intent while avoiding final-class mocking.

### Testing
- Attempted to run the targeted test with `mvn -pl phoenicis-repository test -Dtest=BackgroundRepositoryTest`, but test execution could not complete due to external snapshot dependency resolution failures from JitPack/GraalVM (HTTP 403), so automated test execution is blocked in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f6fd5f6f948326b78b3656eac0c323)