### PR TITLE
ci: add Node 24-ready Maven dependency submission workflow

### DIFF
--- a/.github/workflows/submit-maven.yml
+++ b/.github/workflows/submit-maven.yml
@@ -1,0 +1,25 @@
+name: Maven Dependency Submission
+
+on:
+  push:
+    branches:
+      - master
+
+permissions:
+  contents: write
+
+jobs:
+  submit-maven:
+    runs-on: ubuntu-latest
+    env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - name: Set up JDK 25
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
+        with:
+          distribution: temurin
+          java-version: '25'
+      - name: Submit Maven dependency graph
+        uses: actions/maven-dependency-submission-action@v5


### PR DESCRIPTION
### Motivation
- Proactively avoid the GitHub Actions deprecation of Node.js 20 for JavaScript actions by providing a dedicated Maven dependency submission workflow that opts into Node.js 24 and runs on pushes to `master`.

### Description
- Add `.github/workflows/submit-maven.yml` which defines a `submit-maven` job that sets `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true`, checks out the repository, sets up JDK 25 via `actions/setup-java@v5`, and runs `actions/maven-dependency-submission-action@v5`.

### Testing
- No automated tests were executed for this change; the new workflow will be exercised by GitHub Actions on the next `push` to `master`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7016feed083269be0b6ec22f2c0e7)