### PR TITLE
Add GitHub Actions workflow to submit Maven dependency graph

### DIFF
--- a/.github/workflows/submit-maven.yml
+++ b/.github/workflows/submit-maven.yml
@@ -1,0 +1,25 @@
+name: Maven Dependency Submission
+
+on:
+  push:
+    branches:
+      - master
+
+permissions:
+  contents: write
+
+jobs:
+  submit-maven:
+    runs-on: ubuntu-latest
+    env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - name: Set up JDK 25
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
+        with:
+          distribution: temurin
+          java-version: '25'
+      - name: Submit Maven dependency graph
+        uses: advanced-security/maven-dependency-submission-action@v5


### PR DESCRIPTION
### Motivation
- Add an automated workflow to submit the project's Maven dependency graph to GitHub Advanced Security to improve dependency visibility and vulnerability reporting.

### Description
- Add a new workflow file `/.github/workflows/submit-maven.yml` that triggers on `push` to `master`.
- Configure job `submit-maven` to run on `ubuntu-latest` with `contents: write` permissions and `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24` environment variable set.
- Workflow checks out the repo using `actions/checkout@v6`, sets up JDK 25 with `actions/setup-java` using `temurin`, and executes `advanced-security/maven-dependency-submission-action@v5` to submit the dependency graph.

### Testing
- No automated tests were run as part of this PR; the workflow will execute on the next push to `master` and can be validated by monitoring the Actions run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7016feed083269be0b6ec22f2c0e7)