### PR TITLE
Migrate jackson-databind to relocated `tools.jackson.core:jackson-databind:3.1.4`

### DIFF
--- a/phoenicis-configuration/pom.xml
+++ b/phoenicis-configuration/pom.xml
@@ -50,7 +50,7 @@
             </exclusions>
         </dependency>
         <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
+            <groupId>tools.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
         </dependency>
         <dependency>

--- a/phoenicis-configuration/src/main/java/org/phoenicis/configuration/PhoenicisGlobalConfiguration.java
+++ b/phoenicis-configuration/src/main/java/org/phoenicis/configuration/PhoenicisGlobalConfiguration.java
@@ -18,7 +18,7 @@
 
 package org.phoenicis.configuration;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.databind.ObjectMapper;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.PropertySource;

--- a/phoenicis-containers/src/main/java/org/phoenicis/containers/GenericContainersManager.java
+++ b/phoenicis-containers/src/main/java/org/phoenicis/containers/GenericContainersManager.java
@@ -18,8 +18,8 @@
 
 package org.phoenicis.containers;
 
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.core.type.TypeReference;
+import tools.jackson.databind.ObjectMapper;
 import org.apache.commons.io.FileUtils;
 import org.phoenicis.configuration.security.Safe;
 import org.phoenicis.containers.dto.ContainerCategoryDTO;

--- a/phoenicis-containers/src/main/java/org/phoenicis/containers/dto/ContainerCategoryDTO.java
+++ b/phoenicis-containers/src/main/java/org/phoenicis/containers/dto/ContainerCategoryDTO.java
@@ -18,8 +18,8 @@
 
 package org.phoenicis.containers.dto;
 
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
+import tools.jackson.databind.annotation.JsonDeserialize;
+import tools.jackson.databind.annotation.JsonPOJOBuilder;
 import org.apache.commons.lang.builder.ToStringBuilder;
 
 import java.net.URI;

--- a/phoenicis-engines/src/main/java/org/phoenicis/engines/EnginesManager.java
+++ b/phoenicis-engines/src/main/java/org/phoenicis/engines/EnginesManager.java
@@ -18,8 +18,9 @@
 
 package org.phoenicis.engines;
 
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.core.JacksonException;
+import tools.jackson.core.type.TypeReference;
+import tools.jackson.databind.ObjectMapper;
 import org.graalvm.polyglot.Value;
 import org.phoenicis.configuration.security.Safe;
 import org.phoenicis.engines.dto.EngineCategoryDTO;
@@ -31,7 +32,6 @@ import org.phoenicis.scripts.engine.implementation.PhoenicisScriptEngine;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -131,7 +131,7 @@ public class EnginesManager {
             return objectMapper.readValue(json.toString(), new TypeReference<List<EngineSubCategoryDTO>>() {
                 // Default
             });
-        } catch (IOException e) {
+        } catch (JacksonException e) {
             LOGGER.debug("Unable to deserialize engine json");
             return Collections.emptyList();
         }

--- a/phoenicis-engines/src/main/java/org/phoenicis/engines/dto/EngineCategoryDTO.java
+++ b/phoenicis-engines/src/main/java/org/phoenicis/engines/dto/EngineCategoryDTO.java
@@ -18,8 +18,8 @@
 
 package org.phoenicis.engines.dto;
 
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
+import tools.jackson.databind.annotation.JsonDeserialize;
+import tools.jackson.databind.annotation.JsonPOJOBuilder;
 import org.apache.commons.lang.builder.EqualsBuilder;
 import org.apache.commons.lang.builder.HashCodeBuilder;
 import org.apache.commons.lang.builder.ToStringBuilder;

--- a/phoenicis-engines/src/main/java/org/phoenicis/engines/dto/EngineDTO.java
+++ b/phoenicis-engines/src/main/java/org/phoenicis/engines/dto/EngineDTO.java
@@ -18,8 +18,8 @@
 
 package org.phoenicis.engines.dto;
 
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
+import tools.jackson.databind.annotation.JsonDeserialize;
+import tools.jackson.databind.annotation.JsonPOJOBuilder;
 import org.apache.commons.lang.builder.EqualsBuilder;
 import org.apache.commons.lang.builder.HashCodeBuilder;
 import org.apache.commons.lang.builder.ToStringBuilder;

--- a/phoenicis-engines/src/main/java/org/phoenicis/engines/dto/EngineVersionDTO.java
+++ b/phoenicis-engines/src/main/java/org/phoenicis/engines/dto/EngineVersionDTO.java
@@ -18,8 +18,8 @@
 
 package org.phoenicis.engines.dto;
 
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
+import tools.jackson.databind.annotation.JsonDeserialize;
+import tools.jackson.databind.annotation.JsonPOJOBuilder;
 import org.apache.commons.lang.builder.EqualsBuilder;
 import org.apache.commons.lang.builder.HashCodeBuilder;
 import org.apache.commons.lang.builder.ToStringBuilder;

--- a/phoenicis-javafx/src/main/java/org/phoenicis/javafx/components/library/control/LibraryFeaturePanel.java
+++ b/phoenicis-javafx/src/main/java/org/phoenicis/javafx/components/library/control/LibraryFeaturePanel.java
@@ -1,6 +1,6 @@
 package org.phoenicis.javafx.components.library.control;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.databind.ObjectMapper;
 import javafx.application.Platform;
 import javafx.beans.property.ObjectProperty;
 import javafx.beans.property.SimpleObjectProperty;

--- a/phoenicis-javafx/src/main/java/org/phoenicis/javafx/components/library/control/ShortcutEditingPanel.java
+++ b/phoenicis-javafx/src/main/java/org/phoenicis/javafx/components/library/control/ShortcutEditingPanel.java
@@ -1,6 +1,6 @@
 package org.phoenicis.javafx.components.library.control;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.databind.ObjectMapper;
 import javafx.beans.property.ObjectProperty;
 import javafx.beans.property.SimpleObjectProperty;
 import org.phoenicis.javafx.components.common.control.ControlBase;

--- a/phoenicis-javafx/src/main/java/org/phoenicis/javafx/components/library/control/ShortcutInformationPanel.java
+++ b/phoenicis-javafx/src/main/java/org/phoenicis/javafx/components/library/control/ShortcutInformationPanel.java
@@ -1,6 +1,6 @@
 package org.phoenicis.javafx.components.library.control;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.databind.ObjectMapper;
 import javafx.beans.property.ObjectProperty;
 import javafx.beans.property.SimpleObjectProperty;
 import org.phoenicis.javafx.components.common.control.ControlBase;

--- a/phoenicis-javafx/src/main/java/org/phoenicis/javafx/components/library/skin/ShortcutEditingPanelSkin.java
+++ b/phoenicis-javafx/src/main/java/org/phoenicis/javafx/components/library/skin/ShortcutEditingPanelSkin.java
@@ -1,8 +1,8 @@
 package org.phoenicis.javafx.components.library.skin;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.core.JacksonException;
+import tools.jackson.core.type.TypeReference;
+import tools.jackson.databind.ObjectMapper;
 import javafx.beans.Observable;
 import javafx.beans.binding.StringBinding;
 import javafx.collections.FXCollections;
@@ -145,7 +145,7 @@ public class ShortcutEditingPanelSkin extends SkinBase<ShortcutEditingPanel, Sho
 
                 getControl().setShortcut(new ShortcutDTO.Builder(shortcut)
                         .withScript(json).build());
-            } catch (JsonProcessingException e) {
+            } catch (JacksonException e) {
                 LOGGER.error("Creating new shortcut String failed.", e);
             }
         });
@@ -223,7 +223,7 @@ public class ShortcutEditingPanelSkin extends SkinBase<ShortcutEditingPanel, Sho
 
                             getControl().setShortcut(new ShortcutDTO.Builder(shortcut)
                                     .withScript(json).build());
-                        } catch (JsonProcessingException e) {
+                        } catch (JacksonException e) {
                             LOGGER.error("Creating new shortcut String failed.", e);
                         }
                     }

--- a/phoenicis-javafx/src/main/java/org/phoenicis/javafx/components/library/skin/ShortcutInformationPanelSkin.java
+++ b/phoenicis-javafx/src/main/java/org/phoenicis/javafx/components/library/skin/ShortcutInformationPanelSkin.java
@@ -1,6 +1,6 @@
 package org.phoenicis.javafx.components.library.skin;
 
-import com.fasterxml.jackson.core.type.TypeReference;
+import tools.jackson.core.type.TypeReference;
 import javafx.beans.Observable;
 import javafx.beans.binding.StringBinding;
 import javafx.collections.FXCollections;

--- a/phoenicis-javafx/src/main/java/org/phoenicis/javafx/views/mainwindow/installations/dto/InstallationCategoryDTO.java
+++ b/phoenicis-javafx/src/main/java/org/phoenicis/javafx/views/mainwindow/installations/dto/InstallationCategoryDTO.java
@@ -18,8 +18,8 @@
 
 package org.phoenicis.javafx.views.mainwindow.installations.dto;
 
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
+import tools.jackson.databind.annotation.JsonDeserialize;
+import tools.jackson.databind.annotation.JsonPOJOBuilder;
 import org.apache.commons.lang.builder.EqualsBuilder;
 import org.apache.commons.lang.builder.HashCodeBuilder;
 import org.apache.commons.lang.builder.ToStringBuilder;

--- a/phoenicis-javafx/src/main/java/org/phoenicis/javafx/views/mainwindow/installations/dto/InstallationDTO.java
+++ b/phoenicis-javafx/src/main/java/org/phoenicis/javafx/views/mainwindow/installations/dto/InstallationDTO.java
@@ -18,8 +18,8 @@
 
 package org.phoenicis.javafx.views.mainwindow.installations.dto;
 
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
+import tools.jackson.databind.annotation.JsonDeserialize;
+import tools.jackson.databind.annotation.JsonPOJOBuilder;
 import javafx.scene.Node;
 import org.apache.commons.lang.builder.EqualsBuilder;
 import org.apache.commons.lang.builder.HashCodeBuilder;

--- a/phoenicis-library/pom.xml
+++ b/phoenicis-library/pom.xml
@@ -49,7 +49,7 @@
             <version>${spring.version}</version>
         </dependency>
         <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
+            <groupId>tools.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
         </dependency>
         <dependency>

--- a/phoenicis-library/src/main/java/org/phoenicis/library/LibraryManager.java
+++ b/phoenicis-library/src/main/java/org/phoenicis/library/LibraryManager.java
@@ -18,7 +18,8 @@
 
 package org.phoenicis.library;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.ObjectMapper;
 import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang.StringUtils;
@@ -160,7 +161,7 @@ public class LibraryManager {
     private ShortcutInfoDTO unSerializeShortcutInfo(File jsonFile) {
         try {
             return this.objectMapper.readValue(jsonFile, ShortcutInfoDTO.class);
-        } catch (IOException e) {
+        } catch (JacksonException e) {
             LOGGER.debug("JSON file not found");
             return new ShortcutInfoDTO.Builder().build();
         }

--- a/phoenicis-library/src/main/java/org/phoenicis/library/ShortcutManager.java
+++ b/phoenicis-library/src/main/java/org/phoenicis/library/ShortcutManager.java
@@ -18,7 +18,7 @@
 
 package org.phoenicis.library;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.databind.ObjectMapper;
 import org.apache.commons.io.FileUtils;
 import org.graalvm.polyglot.Value;
 import org.phoenicis.configuration.security.Safe;

--- a/phoenicis-library/src/main/java/org/phoenicis/library/dto/ShortcutCategoryDTO.java
+++ b/phoenicis-library/src/main/java/org/phoenicis/library/dto/ShortcutCategoryDTO.java
@@ -18,8 +18,8 @@
 
 package org.phoenicis.library.dto;
 
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
+import tools.jackson.databind.annotation.JsonDeserialize;
+import tools.jackson.databind.annotation.JsonPOJOBuilder;
 import org.apache.commons.lang.builder.EqualsBuilder;
 import org.apache.commons.lang.builder.HashCodeBuilder;
 import org.apache.commons.lang.builder.ToStringBuilder;

--- a/phoenicis-library/src/main/java/org/phoenicis/library/dto/ShortcutCreationDTO.java
+++ b/phoenicis-library/src/main/java/org/phoenicis/library/dto/ShortcutCreationDTO.java
@@ -18,8 +18,8 @@
 
 package org.phoenicis.library.dto;
 
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
+import tools.jackson.databind.annotation.JsonDeserialize;
+import tools.jackson.databind.annotation.JsonPOJOBuilder;
 import org.apache.commons.lang.builder.EqualsBuilder;
 import org.apache.commons.lang.builder.HashCodeBuilder;
 

--- a/phoenicis-library/src/main/java/org/phoenicis/library/dto/ShortcutDTO.java
+++ b/phoenicis-library/src/main/java/org/phoenicis/library/dto/ShortcutDTO.java
@@ -18,8 +18,8 @@
 
 package org.phoenicis.library.dto;
 
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
+import tools.jackson.databind.annotation.JsonDeserialize;
+import tools.jackson.databind.annotation.JsonPOJOBuilder;
 import org.apache.commons.lang.builder.EqualsBuilder;
 import org.apache.commons.lang.builder.HashCodeBuilder;
 import org.slf4j.Logger;

--- a/phoenicis-library/src/main/java/org/phoenicis/library/dto/ShortcutInfoDTO.java
+++ b/phoenicis-library/src/main/java/org/phoenicis/library/dto/ShortcutInfoDTO.java
@@ -18,8 +18,8 @@
 
 package org.phoenicis.library.dto;
 
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
+import tools.jackson.databind.annotation.JsonDeserialize;
+import tools.jackson.databind.annotation.JsonPOJOBuilder;
 import org.apache.commons.lang.builder.EqualsBuilder;
 import org.apache.commons.lang.builder.HashCodeBuilder;
 

--- a/phoenicis-repository/pom.xml
+++ b/phoenicis-repository/pom.xml
@@ -81,7 +81,7 @@
             <version>2.22.0</version>
         </dependency>
         <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
+            <groupId>tools.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
         </dependency>
         <dependency>

--- a/phoenicis-repository/src/main/java/org/phoenicis/repository/FilesystemJsonRepositoryLocationLoader.java
+++ b/phoenicis-repository/src/main/java/org/phoenicis/repository/FilesystemJsonRepositoryLocationLoader.java
@@ -1,7 +1,8 @@
 package org.phoenicis.repository;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.type.TypeFactory;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.type.TypeFactory;
 import com.google.common.collect.ImmutableList;
 import org.phoenicis.repository.location.ClasspathRepositoryLocation;
 import org.phoenicis.repository.location.GitRepositoryLocation;
@@ -11,7 +12,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.File;
-import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URISyntaxException;
 import java.net.URL;
@@ -62,8 +62,9 @@ public class FilesystemJsonRepositoryLocationLoader implements RepositoryLocatio
         if (repositoryListFile.exists()) {
             try {
                 result = this.objectMapper.readValue(repositoryListFile,
-                        TypeFactory.defaultInstance().constructParametricType(List.class, RepositoryLocation.class));
-            } catch (IOException e) {
+                        TypeFactory.createDefaultInstance()
+                                .constructParametricType(List.class, RepositoryLocation.class));
+            } catch (JacksonException e) {
                 LOGGER.error("Couldn't load repository location list", e);
             }
         } else {
@@ -77,7 +78,7 @@ public class FilesystemJsonRepositoryLocationLoader implements RepositoryLocatio
     public void saveRepositories(List<RepositoryLocation<? extends Repository>> repositoryLocations) {
         try {
             objectMapper.writeValue(new File(repositoryListPath).getAbsoluteFile(), repositoryLocations);
-        } catch (IOException e) {
+        } catch (JacksonException e) {
             LOGGER.error("Couldn't save repository location list", e);
         }
     }

--- a/phoenicis-repository/src/main/java/org/phoenicis/repository/dto/ApplicationDTO.java
+++ b/phoenicis-repository/src/main/java/org/phoenicis/repository/dto/ApplicationDTO.java
@@ -19,8 +19,8 @@
 package org.phoenicis.repository.dto;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
+import tools.jackson.databind.annotation.JsonDeserialize;
+import tools.jackson.databind.annotation.JsonPOJOBuilder;
 import org.apache.commons.lang.builder.EqualsBuilder;
 import org.apache.commons.lang.builder.HashCodeBuilder;
 import org.phoenicis.configuration.localisation.Translatable;

--- a/phoenicis-repository/src/main/java/org/phoenicis/repository/dto/CategoryDTO.java
+++ b/phoenicis-repository/src/main/java/org/phoenicis/repository/dto/CategoryDTO.java
@@ -18,8 +18,8 @@
 
 package org.phoenicis.repository.dto;
 
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
+import tools.jackson.databind.annotation.JsonDeserialize;
+import tools.jackson.databind.annotation.JsonPOJOBuilder;
 import org.apache.commons.lang.builder.EqualsBuilder;
 import org.apache.commons.lang.builder.HashCodeBuilder;
 import org.apache.commons.lang.builder.ToStringBuilder;

--- a/phoenicis-repository/src/main/java/org/phoenicis/repository/dto/RepositoryDTO.java
+++ b/phoenicis-repository/src/main/java/org/phoenicis/repository/dto/RepositoryDTO.java
@@ -18,8 +18,8 @@
 
 package org.phoenicis.repository.dto;
 
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
+import tools.jackson.databind.annotation.JsonDeserialize;
+import tools.jackson.databind.annotation.JsonPOJOBuilder;
 import org.apache.commons.lang.builder.EqualsBuilder;
 import org.apache.commons.lang.builder.HashCodeBuilder;
 import org.apache.commons.lang.builder.ToStringBuilder;

--- a/phoenicis-repository/src/main/java/org/phoenicis/repository/dto/ScriptDTO.java
+++ b/phoenicis-repository/src/main/java/org/phoenicis/repository/dto/ScriptDTO.java
@@ -19,8 +19,8 @@
 package org.phoenicis.repository.dto;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
+import tools.jackson.databind.annotation.JsonDeserialize;
+import tools.jackson.databind.annotation.JsonPOJOBuilder;
 import org.apache.commons.lang.builder.EqualsBuilder;
 import org.apache.commons.lang.builder.HashCodeBuilder;
 import org.phoenicis.configuration.localisation.Translatable;

--- a/phoenicis-repository/src/main/java/org/phoenicis/repository/dto/TranslationDTO.java
+++ b/phoenicis-repository/src/main/java/org/phoenicis/repository/dto/TranslationDTO.java
@@ -18,8 +18,8 @@
 
 package org.phoenicis.repository.dto;
 
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
+import tools.jackson.databind.annotation.JsonDeserialize;
+import tools.jackson.databind.annotation.JsonPOJOBuilder;
 import org.apache.commons.lang.builder.EqualsBuilder;
 import org.apache.commons.lang.builder.HashCodeBuilder;
 import org.apache.commons.lang.builder.ToStringBuilder;

--- a/phoenicis-repository/src/main/java/org/phoenicis/repository/dto/TypeDTO.java
+++ b/phoenicis-repository/src/main/java/org/phoenicis/repository/dto/TypeDTO.java
@@ -18,8 +18,8 @@
 
 package org.phoenicis.repository.dto;
 
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
+import tools.jackson.databind.annotation.JsonDeserialize;
+import tools.jackson.databind.annotation.JsonPOJOBuilder;
 import org.apache.commons.lang.builder.EqualsBuilder;
 import org.apache.commons.lang.builder.HashCodeBuilder;
 import org.apache.commons.lang.builder.ToStringBuilder;

--- a/phoenicis-repository/src/main/java/org/phoenicis/repository/location/ClasspathRepositoryLocation.java
+++ b/phoenicis-repository/src/main/java/org/phoenicis/repository/location/ClasspathRepositoryLocation.java
@@ -2,7 +2,7 @@ package org.phoenicis.repository.location;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import tools.jackson.databind.annotation.JsonDeserialize;
 import org.apache.commons.lang.builder.EqualsBuilder;
 import org.apache.commons.lang.builder.HashCodeBuilder;
 import org.apache.commons.lang.builder.ToStringBuilder;

--- a/phoenicis-repository/src/main/java/org/phoenicis/repository/location/GitRepositoryLocation.java
+++ b/phoenicis-repository/src/main/java/org/phoenicis/repository/location/GitRepositoryLocation.java
@@ -1,7 +1,7 @@
 package org.phoenicis.repository.location;
 
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
+import tools.jackson.databind.annotation.JsonDeserialize;
+import tools.jackson.databind.annotation.JsonPOJOBuilder;
 import org.apache.commons.lang.builder.EqualsBuilder;
 import org.apache.commons.lang.builder.HashCodeBuilder;
 import org.apache.commons.lang.builder.ToStringBuilder;

--- a/phoenicis-repository/src/main/java/org/phoenicis/repository/location/LocalRepositoryLocation.java
+++ b/phoenicis-repository/src/main/java/org/phoenicis/repository/location/LocalRepositoryLocation.java
@@ -2,7 +2,7 @@ package org.phoenicis.repository.location;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import tools.jackson.databind.annotation.JsonDeserialize;
 import org.apache.commons.lang.builder.EqualsBuilder;
 import org.apache.commons.lang.builder.HashCodeBuilder;
 import org.apache.commons.lang.builder.ToStringBuilder;

--- a/phoenicis-repository/src/main/java/org/phoenicis/repository/types/ClasspathRepository.java
+++ b/phoenicis-repository/src/main/java/org/phoenicis/repository/types/ClasspathRepository.java
@@ -18,7 +18,8 @@
 
 package org.phoenicis.repository.types;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.ObjectMapper;
 import org.apache.commons.compress.utils.IOUtils;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.lang.builder.EqualsBuilder;
@@ -113,7 +114,7 @@ public class ClasspathRepository implements Repository {
                 LOGGER.debug(String.format("type.json %s for classpath repository does not exist", jsonTypePath));
                 return new TypeDTO.Builder().build();
             }
-        } catch (IOException e) {
+        } catch (JacksonException e) {
             throw new RepositoryException("Could not build type", e);
         }
     }
@@ -175,7 +176,7 @@ public class ClasspathRepository implements Repository {
                         jsonCategoryPath));
                 return new CategoryDTO.Builder().build();
             }
-        } catch (IOException e) {
+        } catch (JacksonException e) {
             throw new RepositoryException("Could not build category", e);
         }
     }
@@ -240,7 +241,7 @@ public class ClasspathRepository implements Repository {
                             applicationDTOBuilder.getId(), typeFileName, categoryFileName, applicationFileName))
                     .withMiniatures(buildMiniatures(typeFileName, categoryFileName, applicationFileName));
             return applicationDTOBuilder.build();
-        } catch (IOException e) {
+        } catch (JacksonException e) {
             throw new RepositoryException("Could not build application", e);
         }
     }

--- a/phoenicis-repository/src/main/java/org/phoenicis/repository/types/LocalRepository.java
+++ b/phoenicis-repository/src/main/java/org/phoenicis/repository/types/LocalRepository.java
@@ -18,7 +18,8 @@
 
 package org.phoenicis.repository.types;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.ObjectMapper;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.lang.builder.EqualsBuilder;
@@ -351,7 +352,7 @@ public final class LocalRepository implements Repository {
     private TypeDTO unSerializeType(File jsonFile) {
         try {
             return objectMapper.readValue(jsonFile, TypeDTO.class);
-        } catch (IOException e) {
+        } catch (JacksonException e) {
             LOGGER.debug("JSON file not found", e);
             return new TypeDTO.Builder().build();
         }
@@ -360,7 +361,7 @@ public final class LocalRepository implements Repository {
     private CategoryDTO unSerializeCategory(File jsonFile) {
         try {
             return objectMapper.readValue(jsonFile, CategoryDTO.class);
-        } catch (IOException e) {
+        } catch (JacksonException e) {
             LOGGER.debug("JSON file not found", e);
             return new CategoryDTO.Builder().build();
         }
@@ -369,7 +370,7 @@ public final class LocalRepository implements Repository {
     private ScriptDTO unSerializeScript(File jsonFile) {
         try {
             return objectMapper.readValue(jsonFile, ScriptDTO.class);
-        } catch (IOException e) {
+        } catch (JacksonException e) {
             LOGGER.debug("JSON file not found");
             return new ScriptDTO.Builder().build();
         }
@@ -378,7 +379,7 @@ public final class LocalRepository implements Repository {
     private ApplicationDTO unSerializeApplication(File jsonFile) {
         try {
             return objectMapper.readValue(jsonFile, ApplicationDTO.class);
-        } catch (IOException e) {
+        } catch (JacksonException e) {
             LOGGER.debug("JSON file not found", e);
             return new ApplicationDTO.Builder().build();
         }

--- a/phoenicis-repository/src/test/java/org/phoenicis/repository/types/ClasspathRepositoryTest.java
+++ b/phoenicis-repository/src/test/java/org/phoenicis/repository/types/ClasspathRepositoryTest.java
@@ -18,7 +18,7 @@
 
 package org.phoenicis.repository.types;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.databind.ObjectMapper;
 import org.junit.Test;
 import org.phoenicis.repository.dto.CategoryDTO;
 import org.springframework.core.io.support.PathMatchingResourcePatternResolver;

--- a/phoenicis-settings/pom.xml
+++ b/phoenicis-settings/pom.xml
@@ -49,7 +49,7 @@
             <version>${spring.version}</version>
         </dependency>
         <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
+            <groupId>tools.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
         </dependency>
         <dependency>

--- a/phoenicis-tests/src/test/java/org/phoenicis/tests/DTOContractTest.java
+++ b/phoenicis-tests/src/test/java/org/phoenicis/tests/DTOContractTest.java
@@ -19,10 +19,10 @@
 package org.phoenicis.tests;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.DeserializationFeature;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.DeserializationFeature;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.annotation.JsonPOJOBuilder;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -135,7 +135,7 @@ public class DTOContractTest {
     }
 
     @Test
-    public void testSerialize() throws ReflectiveOperationException, JsonProcessingException, URISyntaxException {
+    public void testSerialize() throws ReflectiveOperationException, JacksonException, URISyntaxException {
         final Object dto = newDTOInstance(DTOContainer.getClazz());
         final String json = objectMapper.writeValueAsString(dto);
         assertTrue(json.startsWith("{"));
@@ -147,8 +147,9 @@ public class DTOContractTest {
         final Object dto = newDTOInstance(DTOContainer.getClazz());
         final String json = objectMapper.writeValueAsString(dto);
 
-        final ObjectMapper alternativeObjectMapper = new ObjectMapper();
-        alternativeObjectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+        final ObjectMapper alternativeObjectMapper = new ObjectMapper().rebuild()
+                .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
+                .build();
 
         final Object serialized = alternativeObjectMapper.readValue(json, DTOContainer.getClazz());
 

--- a/phoenicis-tools/pom.xml
+++ b/phoenicis-tools/pom.xml
@@ -79,7 +79,7 @@
             <version>2.6</version>
         </dependency>
         <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
+            <groupId>tools.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
         </dependency>
         <dependency>

--- a/phoenicis-tools/src/main/java/org/phoenicis/tools/config/CompatibleConfigFileFormat.java
+++ b/phoenicis-tools/src/main/java/org/phoenicis/tools/config/CompatibleConfigFileFormat.java
@@ -18,9 +18,10 @@
 
 package org.phoenicis.tools.config;
 
-import com.fasterxml.jackson.core.JsonParseException;
-import com.fasterxml.jackson.databind.JsonMappingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.core.exc.JacksonIOException;
+import tools.jackson.core.exc.StreamReadException;
+import tools.jackson.databind.DatabindException;
+import tools.jackson.databind.ObjectMapper;
 import org.phoenicis.configuration.security.Safe;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -81,13 +82,13 @@ public class CompatibleConfigFileFormat implements ConfigFile {
                 }
             }
             return results;
-        } catch (JsonParseException | JsonMappingException e) {
+        } catch (StreamReadException | DatabindException e) {
             LOGGER.debug("The file does not seems to be a JSON format. Trying legacy Phoenicis config file.", e);
             return getLegacyMap();
-        } catch (IOException e) {
+        } catch (JacksonIOException e) {
             LOGGER.debug(String.format(
                     "Couldn't read the config file %s. Will assume that the config file is empty. This can happen e.g. if a new container is just being created.",
-                    configFile.getAbsolutePath()));
+                    configFile.getAbsolutePath()), e);
             return new HashMap<>();
         }
     }

--- a/phoenicis-tools/src/main/java/org/phoenicis/tools/config/CompatibleConfigFileFormatFactory.java
+++ b/phoenicis-tools/src/main/java/org/phoenicis/tools/config/CompatibleConfigFileFormatFactory.java
@@ -18,7 +18,7 @@
 
 package org.phoenicis.tools.config;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.databind.ObjectMapper;
 import org.phoenicis.configuration.security.Safe;
 
 import java.io.File;

--- a/phoenicis-tools/src/test/java/org/phoenicis/tools/config/CompatibleConfigFileFormatTest.java
+++ b/phoenicis-tools/src/test/java/org/phoenicis/tools/config/CompatibleConfigFileFormatTest.java
@@ -18,7 +18,7 @@
 
 package org.phoenicis.tools.config;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.databind.ObjectMapper;
 import org.junit.Before;
 import org.junit.Test;
 

--- a/pom.xml
+++ b/pom.xml
@@ -76,9 +76,9 @@
                 <scope>test</scope>
             </dependency>
             <dependency>
-                <groupId>com.fasterxml.jackson.core</groupId>
+                <groupId>tools.jackson.core</groupId>
                 <artifactId>jackson-databind</artifactId>
-                <version>2.22.0</version>
+                <version>3.1.4</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.logging.log4j</groupId>


### PR DESCRIPTION
### Motivation
- Replace the old `com.fasterxml.jackson.core:jackson-databind` coordinates with the relocated artifact used by Jackson 3 to pick up the relocated packages and newer API. 
- Update source to compile against Jackson 3 API surface (relocated `tools.jackson.*` packages) and adapt to API changes (exceptions, `ObjectMapper` builder, `TypeFactory`).
- Keep Jackson annotations (`com.fasterxml.jackson.annotation`) as-is where those classes remain in the original package.

### Description
- Updated managed dependency coordinates to `tools.jackson.core:jackson-databind:3.1.4` in the root `pom.xml` and switched module `pom.xml` entries to `tools.jackson.core` where applicable. 
- Replaced imports across modules from `com.fasterxml.jackson.databind`/`com.fasterxml.jackson.core` to the relocated `tools.jackson.databind`/`tools.jackson.core` packages for databind/core usage while preserving `com.fasterxml.jackson.annotation` imports for annotations. 
- Adjusted exception handling to Jackson 3 types: replaced `JsonProcessingException` / `JsonParseException` / `JsonMappingException` usages with `JacksonException` / `StreamReadException` / `DatabindException` / `JacksonIOException` as appropriate. 
- Updated `ObjectMapper` reconfiguration to Jackson 3 immutable builder style (`new ObjectMapper().rebuild().configure(...).build()`), and replaced `TypeFactory.defaultInstance()` with `TypeFactory.createDefaultInstance()` where needed. 

### Testing
- Ran `git diff --check` with no whitespace errors reported. (passed)
- Ran `mvn -q -pl phoenicis-configuration -am test` to validate the configuration module and its tests (succeeded).
- Ran a full project compile with `mvn -q -DskipTests compile` which was blocked by external dependency resolution errors for `com.github.PhoenicisOrg:jmimemagic:0.3.3` and `com.github.PhoenicisOrg:lnk-parser:1.0.0` from JitPack (JitPack returned 403), so not all modules could be compiled in this environment.
- Verified Jackson 3 artifacts from Maven Central and inspected classes (`ObjectMapper`, `TypeFactory`) to confirm API compatibility with the applied code changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2684033fd4832694dd5b8b663ff6f0)